### PR TITLE
RH: Added ability to put all data into a new index every day 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VX.X
 
 - Initial connector which outputs all analytics into a single elasticsearch index
+- Enabled the ES connecter to save all output to a rolling index rather than a static index
 
 ## v0.1
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ Create a `pump.conf` file:
             "meta": {
                 "index_name": "tyk_analytics",
                 "elasticsearch_url": "localhost:9200",
-                "enable_sniffing": "false",
-                "document_type": "tyk_analytics"
+                "enable_sniffing": false,
+                "document_type": "tyk_analytics",
+                "rolling_index": false
             }
         }
     },
@@ -75,3 +76,5 @@ Settings are the same as for the original `tyk.conf` for redis and for mongoDB.
 `"enable_sniffing"` - If sniffing is enabled, the "elasticsearch_url" will be used to make a request to get a list of all the nodes in the cluster, the returned addresses will then be used. Defaults to false
 
 `"document_type"` - The type of the document that is created in ES. Defaults to "tyk_analytics"
+
+`"rolling_index"` - Appends the date to the end of the index name, so each days data is split into a different index name. E.g. tyk_analytics-2016.02.28 Defaults to false


### PR DESCRIPTION
Rather than one static index

In ES, this enables easy backups to be taken of individual days worth of logs, and for index settings changing at midnight without having to reindex all existing data

Also removed the explicit "CreateIndex" call as by default when you insert a document into an index for the first time it creates the index in ES. Could add this back in as an option later

Branched off from develop this time? Which would you prefer I worked from / merged into?