### PR TITLE
Add Segment analytics pump

### DIFF
--- a/pumps/init.go
+++ b/pumps/init.go
@@ -15,4 +15,5 @@ func init() {
 	AvailablePumps["mongo"] = &MongoPump{}
 	AvailablePumps["csv"] = &CSVPump{}
 	AvailablePumps["elasticsearch"] = &ElasticsearchPump{}
+	AvailablePumps["segment"] = &SegmentPump{}
 }

--- a/pumps/pump.go
+++ b/pumps/pump.go
@@ -21,6 +21,8 @@ func GetPumpByName(name string) (Pump, error) {
 		return AvailablePumps["elasticsearch"], nil
 	case "csv":
 		return AvailablePumps["csv"], nil
+	case "segment":
+		return AvailablePumps["segment"], nil
 	}
 
 	return nil, errors.New("Not found")

--- a/pumps/segment.go
+++ b/pumps/segment.go
@@ -1,0 +1,99 @@
+package pumps
+
+import (
+	"fmt"
+	"encoding/json"
+	"errors"
+	"github.com/Sirupsen/logrus"
+	segment "github.com/Segment/analytics-go"
+)
+
+type SegmentPump struct {
+	segmentClient *segment.Client
+	segmentConf   *SegmentConf
+}
+
+var segmentPrefix string = "segment-pump"
+
+type SegmentConf struct {
+	WriteKey string `mapstructure:"segment_write_key"`
+}
+
+func (s *SegmentPump) New() Pump {
+	newPump := SegmentPump{}
+	return &newPump
+}
+
+func (s *SegmentPump) GetName() string {
+	return "Segment Pump"
+}
+
+func (s *SegmentPump) Init(config interface{}) error {
+	s.segmentConf = &SegmentConf{}
+	loadConfigErr := mapstructure.Decode(config, &s.segmentConf)
+
+	if loadConfigErr != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": segmentPrefix,
+		}).Fatal("Failed to decode configuration: ", loadConfigErr)
+	}
+
+	s.segmentClient = segment.New(s.segmentConf.WriteKey)
+
+	return nil
+}
+
+func (s *SegmentPump) WriteData(data []interface{}) error {
+	log.WithFields(logrus.Fields{
+		"prefix": segmentPrefix,
+	}).Info("Writing ", len(data), " records")
+
+	for i, v := range data {
+		analyticsRecord := AnalyticsRecord{}
+		err := msgpack.Unmarshal(v.([]byte), &analyticsRecord)
+		log.Debug("Decoded record: ", analyticsRecord)
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"prefix": segmentPrefix,
+			}).Error("Couldn't unmarshal analytics data:", err)
+		} else {
+			s.WriteDataRecord(analyticsRecord)
+		}
+	}
+
+	return nil
+}
+
+func (s *SegmentPump) WriteDataRecord(record AnalyticsRecord) error {
+	key := record.APIKey
+	properties, err := s.ToJSONMap(record)
+
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"prefix": segmentPrefix,
+		}).Error("Couldn't marshal analytics data:", err)
+	} else {
+		s.segmentClient.Track(&segment.Track{
+			Event:       "Hit",
+			AnonymousId: key,
+			Properties:  properties,
+		})
+	}
+
+	return nil
+}
+
+func (s *SegmentPump) ToJSONMap(obj interface{}) (map[string]interface{}, error) {
+	ev, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var properties map[string]interface{}
+	err = json.Unmarshal(ev, &properties)
+	if err != nil {
+		return nil, err
+	}
+
+	return properties, nil
+}


### PR DESCRIPTION
Adds a pump for https://segment.com

It would be nice for an analytics pump to be able to identify keys - i.e. when a key is created the pump gets the chance to record the email/meta data associated with that key.