### PR TITLE
Elasticsearch Extended Stats Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Create a `pump.conf` file:
                 "elasticsearch_url": "localhost:9200",
                 "enable_sniffing": false,
                 "document_type": "tyk_analytics",
-                "rolling_index": false
+                "rolling_index": false,
             }
         },
         "influx": {
@@ -139,3 +139,4 @@ Settings are the same as for the original `tyk.conf` for redis and for mongoDB.
 
 `"rolling_index"` - Appends the date to the end of the index name, so each days data is split into a different index name. E.g. tyk_analytics-2016.02.28 Defaults to false
 
+`"extended_stats"` - If set to true will include the following additional fields: Raw Request, Raw Response and User Agent.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Create a `pump.conf` file:
                 "enable_sniffing": false,
                 "document_type": "tyk_analytics",
                 "rolling_index": false,
+                "extended_stats": false
             }
         },
         "influx": {

--- a/pumps/elasticsearch.go
+++ b/pumps/elasticsearch.go
@@ -16,11 +16,12 @@ type ElasticsearchPump struct {
 var elasticsearchPrefix string = "elasticsearch-pump"
 
 type ElasticsearchConf struct {
-	IndexName        string `mapstructure:"index_name"`
-	ElasticsearchURL string `mapstructure:"elasticsearch_url"`
-	EnableSniffing   bool   `mapstructure:"use_sniffing"`
-	DocumentType     string `mapstructure:"document_type"`
-	RollingIndex     bool   `mapstructure:"rolling_index"`
+	IndexName          string `mapstructure:"index_name"`
+	ElasticsearchURL   string `mapstructure:"elasticsearch_url"`
+	EnableSniffing     bool   `mapstructure:"use_sniffing"`
+	DocumentType       string `mapstructure:"document_type"`
+	RollingIndex       bool   `mapstructure:"rolling_index"`
+	ExtendedStatistics bool   `mapstructure:"extended_stats"`
 }
 
 func (e *ElasticsearchPump) New() Pump {
@@ -126,6 +127,7 @@ func (e *ElasticsearchPump) WriteData(data []interface{}) error {
 					"oauth_id":        record.OauthID,
 					"request_time_ms": record.RequestTime,
 				}
+
 
 				var _, err = index.BodyJson(mapping).Type(e.esConf.DocumentType).Do()
 				if err != nil {

--- a/pumps/elasticsearch.go
+++ b/pumps/elasticsearch.go
@@ -128,6 +128,11 @@ func (e *ElasticsearchPump) WriteData(data []interface{}) error {
 					"request_time_ms": record.RequestTime,
 				}
 
+				if e.esConf.ExtendedStatistics {
+					mapping["raw_request"] := record.RawRequest
+					mapping["raw_response"] := record.RawResponse
+					mapping["user_agent"] := record.UserAgent
+				}
 
 				var _, err = index.BodyJson(mapping).Type(e.esConf.DocumentType).Do()
 				if err != nil {


### PR DESCRIPTION
Adds an "extended_stats" flag which changes the behavior of the Elasticsearch pump to include the following additional fields in the Elasticsearch payload:

* Raw Request
* Raw Response
* User Agent

Defaults to false if not specified which should ensure backward compatibility with existing users. Depending on raw request or response sizes could impact on performance which is why this has been implemented as an optional flag.