### PR TITLE
Upgrade to support Elasticsearch 5

### DIFF
--- a/pumps/elasticsearch.go
+++ b/pumps/elasticsearch.go
@@ -4,8 +4,9 @@ import (
 	"github.com/TykTechnologies/logrus"
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/mitchellh/mapstructure"
-	"gopkg.in/olivere/elastic.v3"
+	"gopkg.in/olivere/elastic.v5"
 	"time"
+	"context"
 )
 
 type ElasticsearchPump struct {
@@ -134,7 +135,7 @@ func (e *ElasticsearchPump) WriteData(data []interface{}) error {
 					mapping["user_agent"] = record.UserAgent
 				}
 
-				var _, err = index.BodyJson(mapping).Type(e.esConf.DocumentType).Do()
+				var _, err = index.BodyJson(mapping).Type(e.esConf.DocumentType).Do(context.Background())
 				if err != nil {
 					log.WithFields(logrus.Fields{
 						"prefix": elasticsearchPrefix,


### PR DESCRIPTION
A simple change, just using version 5 of the Go Elastic package (`gopkg.in/olivere/elastic.v5`), as suggested in #20. The full list of breaking changes between 3 and 5 is [here](https://github.com/olivere/elastic/blob/release-branch.v5/CHANGELOG-5.0.md#enforce-contextcontext-in-performrequest-and-do), not much that affects us, other than the `Do()` method now requires a `context.context`. I have tested this with Elasticsearch 5.0.1. 
Will break compatibility with older versions of Elasticsearch; I did experiment with a [more complex change that would support both versions](https://github.com/TykTechnologies/tyk-pump/compare/develop...miles-b:feature/elasticsearch-5), but in the end I decided its probably better to keep it simple