### PR TITLE
Allow mongo connection errors to fail

### DIFF
--- a/pump.example.conf
+++ b/pump.example.conf
@@ -1,5 +1,5 @@
 {
-	"analytics_storage_type": "redis",
+    "analytics_storage_type": "redis",
     "analytics_storage_config": {
         "type": "redis",
         "host": "localhost",
@@ -18,7 +18,8 @@
             "name": "mongo",
             "meta": {
                 "collection_name": "tyk_analytics",
-                "mongo_url": "mongodb://localhost/tyk_analytics"
+                "mongo_url": "mongodb://localhost/tyk_analytics",
+                "mongo_connect_fail_fast": true
             }
         }
     },


### PR DESCRIPTION
Last night we suffered an outage where pump could no longer talk to mongo and redis filled up, causing things like gateway enroll/re-enrolls and key operations to fail.

This looks related to https://github.com/TykTechnologies/tyk-pump/issues/16

This was due to, or at least could have been mitigated by, `mgo.DialWithInfo()` not passing a `*mgo.DialInfo` with a timeout or the `FailFast` flag being set- the connection churned and churned and churned.

This PR proposes an optional config key: `mongo_connect_fail_fast`. This is used to both fail the connection fast, and to kill the process should this occur.

Killing the process allows monitoring systems to pick the defect up. In our case this would have solved the connection problem we had. For other's it'll help alert people to problems.

*Note:* the redis client also keeps churning away silently- why?