### PR TITLE
Add Splunk pump

### DIFF
--- a/pumps/init.go
+++ b/pumps/init.go
@@ -20,4 +20,5 @@ func init() {
 	AvailablePumps["statsd"] = &StatsdPump{}
 	AvailablePumps["segment"] = &SegmentPump{}
 	AvailablePumps["graylog"] = &GraylogPump{}
+	AvailablePumps["splunk"] = &SplunkPump{}
 }

--- a/pumps/pump.go
+++ b/pumps/pump.go
@@ -35,6 +35,8 @@ func GetPumpByName(name string) (Pump, error) {
 		return AvailablePumps["segment"], nil
 	case "graylog":
 		return AvailablePumps["graylog"], nil
+	case "splunk":
+		return AvailablePumps["splunk"], nil
 	}
 
 	return nil, errors.New("Not found")

--- a/pumps/splunk.go
+++ b/pumps/splunk.go
@@ -1,0 +1,154 @@
+package pumps
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/TykTechnologies/logrus"
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/mitchellh/mapstructure"
+)
+
+const (
+	defaultPath      = "/services/collector/event/1.0"
+	authHeaderName   = "authorization"
+	authHeaderPrefix = "Splunk "
+	pumpPrefix       = "splunk-pump"
+	pumpName         = "Splunk Pump"
+)
+
+var (
+	errInvalidSettings = errors.New("Empty settings")
+)
+
+// SplunkClient contains Splunk client methods.
+type SplunkClient struct {
+	Token         string
+	CollectorURL  string
+	TLSSkipVerify bool
+
+	httpClient *http.Client
+}
+
+// NewSplunkClient initializes a new SplunkClient.
+func NewSplunkClient(token string, collectorURL string, skipVerify bool) (c *SplunkClient, err error) {
+	if token == "" || collectorURL == "" {
+		return c, errInvalidSettings
+	}
+	u, err := url.Parse(collectorURL)
+	if err != nil {
+		return c, err
+	}
+	// Append the default collector API path:
+	u.Path = defaultPath
+	c = &SplunkClient{
+		Token:        token,
+		CollectorURL: u.String(),
+		httpClient:   http.DefaultClient,
+	}
+	if skipVerify {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		c.httpClient = &http.Client{Transport: tr}
+	}
+	return c, nil
+}
+
+// Send sends an event to the Splunk HTTP Event Collector interface.
+func (c *SplunkClient) Send(event map[string]interface{}, ts time.Time) (*http.Response, error) {
+	eventWrap := struct {
+		Time  int64                  `json:"time"`
+		Event map[string]interface{} `json:"event"`
+	}{Event: event}
+	eventWrap.Time = ts.Unix()
+	eventJSON, err := json.Marshal(eventWrap)
+	if err != nil {
+		return nil, err
+	}
+	reader := bytes.NewReader(eventJSON)
+	req, err := http.NewRequest("POST", c.CollectorURL, reader)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add(authHeaderName, authHeaderPrefix+c.Token)
+	return c.httpClient.Do(req)
+}
+
+// SplunkPump is a Tyk Pump driver for Splunk.
+type SplunkPump struct {
+	client *SplunkClient
+	config *SplunkPumpConfig
+}
+
+// SplunkPumpConfig contains the driver configuration parameters.
+type SplunkPumpConfig struct {
+	CollectorToken string `mapstructure:"collector_token"`
+	CollectorURL   string `mapstructure:"collector_url"`
+	TLSSkipVerify  bool   `mapstructure:"tls_skip_verify"`
+}
+
+// New initializes a new pump.
+func (p *SplunkPump) New() Pump {
+	return &SplunkPump{}
+}
+
+// GetName returns the pump name.
+func (p *SplunkPump) GetName() string {
+	return pumpName
+}
+
+// Init performs the initialization of the SplunkClient.
+func (p *SplunkPump) Init(config interface{}) error {
+	p.config = &SplunkPumpConfig{}
+	err := mapstructure.Decode(config, p.config)
+	if err != nil {
+		return err
+	}
+	log.WithFields(logrus.Fields{
+		"prefix": pumpPrefix,
+	}).Infof("%s Endpoint: %s", pumpName, p.config.CollectorURL)
+
+	p.client, err = NewSplunkClient(p.config.CollectorToken, p.config.CollectorURL, p.config.TLSSkipVerify)
+	if err != nil {
+		return err
+	}
+
+	log.WithFields(logrus.Fields{
+		"prefix": pumpPrefix,
+	}).Debugf("%s Initialized", pumpName)
+	return nil
+}
+
+// WriteData prepares an appropriate data structure and sends it to the HTTP Event Collector.
+func (p *SplunkPump) WriteData(data []interface{}) error {
+	log.WithFields(logrus.Fields{
+		"prefix": pumpPrefix,
+	}).Info("Writing ", len(data), " records")
+	for _, v := range data {
+		decoded := v.(analytics.AnalyticsRecord)
+		event := map[string]interface{}{
+			"method":        decoded.Method,
+			"path":          decoded.Path,
+			"response_code": decoded.ResponseCode,
+			"api_key":       decoded.APIKey,
+			"time_stamp":    decoded.TimeStamp,
+			"api_version":   decoded.APIVersion,
+			"api_name":      decoded.APIName,
+			"api_id":        decoded.APIID,
+			"org_id":        decoded.OrgID,
+			"oauth_id":      decoded.OauthID,
+			"raw_request":   decoded.RawRequest,
+			"request_time":  decoded.RequestTime,
+			"raw_response":  decoded.RawResponse,
+			"ip_address":    decoded.IPAddress,
+		}
+		p.client.Send(event, decoded.TimeStamp)
+	}
+	return nil
+}

--- a/pumps/splunk_test.go
+++ b/pumps/splunk_test.go
@@ -1,0 +1,90 @@
+package pumps
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testToken       = "85FBC7DE-451F-4FBE-B847-2797D3510464"
+	testEndpointURL = "http://localhost:8088/services/collector"
+)
+
+type splunkStatus struct {
+	Text string `json:"text"`
+	Code int32  `json:"code"`
+}
+type testHandler struct {
+	test *testing.T
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	authHeaderValue := r.Header.Get("authorization")
+	if authHeaderValue == "" {
+		h.test.Fatal("Auth header is empty")
+	}
+	expectedValue := authHeaderPrefix + testToken
+	if strings.Compare(authHeaderValue, expectedValue) != 0 {
+		h.test.Fatalf("Auth header value doesn't match, got: %s, expected: %s", authHeaderValue, expectedValue)
+	}
+	if r.Body == nil {
+		h.test.Fatal("Body is nil")
+	}
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		h.test.Fatal("Couldn't ready body")
+	}
+	event := make(map[string]interface{})
+	err = json.Unmarshal(body, &event)
+	if err != nil {
+		h.test.Fatal("Couldn't unmarshal event data")
+	}
+	status := splunkStatus{Text: "Success", Code: 0}
+	statusJSON, _ := json.Marshal(&status)
+	w.Write(statusJSON)
+}
+
+func TestSplunkInit(t *testing.T) {
+	_, err := NewSplunkClient("", testEndpointURL, true)
+	if err == nil {
+		t.Fatal("A token needs to be present")
+	}
+	_, err = NewSplunkClient(testToken, "", true)
+	if err == nil {
+		t.Fatal("An endpoint needs to be present")
+	}
+	_, err = NewSplunkClient("", "", true)
+	if err == nil {
+		t.Fatal("Empty parameters should return an error")
+	}
+}
+
+func TestSplunkSend(t *testing.T) {
+	handler := &testHandler{t}
+	server := httptest.NewServer(handler)
+	defer server.Close()
+	client, _ := NewSplunkClient(testToken, server.URL, true)
+	e := map[string]interface{}{
+		"method": "POST",
+		"api_id": "123",
+		"path":   "/test-path",
+	}
+	res, err := client.Send(e, time.Now())
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status := new(splunkStatus)
+	err = json.Unmarshal(body, &status)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Code != 0 || status.Text != "Success" {
+		t.Fatalf("Bad status")
+	}
+}


### PR DESCRIPTION
This is a simple wrapper that interacts with the Splunk HTTP Event Collector service, following the format that's specified [here](http://dev.splunk.com/view/event-collector/SP-CAAAE6P).

<img width="988" alt="splunkpump" src="https://user-images.githubusercontent.com/20110/33759559-8a05b686-dbe1-11e7-8d93-a74914c92128.png">


A sample configuration looks like this:
```json
    "pumps": {
        "splunk": {
            "name": "splunk",
            "meta": {
                "collector_token": "85FBC7DE-A1A1-A1A1-A1A1-A197D3510464",
                "collector_url": "https://input-prd-p-xyz.cloud.splunk.com:8088",
                "tls_skip_verify": true
            }
        }
    },
```

This is the result of some tweaks around my initial work on `go-splunk`, I've updated it a bit to take the timestamp from the actual request and attach it to the event in the way the HTTP Event Collector expects.
The TLS part needs some work, I'm thinking that the Splunk Cloud platform I'm using for tests provides a certificate that we can use.`tls_skip_verify` is useful for development purposes, for now.