### PR TITLE
Update pump.conf to include mongo aggregates pump

### DIFF
--- a/pump.example.conf
+++ b/pump.example.conf
@@ -1,34 +1,41 @@
 {
-	"analytics_storage_type": "redis",
+  "analytics_storage_type": "redis",
     "analytics_storage_config": {
-        "type": "redis",
-        "host": "localhost",
-        "port": 6379,
-        "hosts": null,
-        "username": "",
-        "password": "",
-        "database": 0,
-        "optimisation_max_idle": 100,
-        "optimisation_max_active": 0,
-        "enable_cluster": false
-    },
-    "purge_delay": 10,
-    "pumps": {
-        "mongo": {
-            "name": "mongo",
-            "meta": {
-                "collection_name": "tyk_analytics",
-                "mongo_url": "mongodb://localhost/tyk_analytics",
-                "collection_cap_max_size_bytes": 1048576,
-                "collection_cap_enable": true
-            }
-        }
-    },
-    "uptime_pump_config": {
-        "collection_name": "tyk_uptime_analytics",
+    "type": "redis",
+    "host": "localhost",
+    "port": 6379,
+    "hosts": null,
+    "username": "",
+    "password": "",
+    "database": 0,
+    "optimisation_max_idle": 100,
+    "optimisation_max_active": 0,
+    "enable_cluster": false
+  },
+  "purge_delay": 10,
+  "pumps": {
+    "mongo": 
+      "name": "mongo",
+      "meta": {
+        "collection_name": "tyk_analytics",
         "mongo_url": "mongodb://localhost/tyk_analytics",
         "collection_cap_max_size_bytes": 1048576,
         "collection_cap_enable": true
+      }
     },
-    "dont_purge_uptime_data": false
+    "mongo-pump-aggregate": {
+      "name": "mongo-pump-aggregate",
+      "meta": {
+        "mongo_url": "mongodb://localhost/tyk_analytics",
+        "use_mixed_collection": true
+      }
+    }
+  },
+  "uptime_pump_config": {
+    "collection_name": "tyk_uptime_analytics",
+    "mongo_url": "mongodb://localhost/tyk_analytics",
+    "collection_cap_max_size_bytes": 1048576,
+    "collection_cap_enable": true
+  },
+  "dont_purge_uptime_data": false
 }


### PR DESCRIPTION
This pump is required for users to see analytics graphs in their installs so should be present as default.