### PR TITLE
Create better MongoDB indices for corresponding pumps

### DIFF
--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -129,42 +129,17 @@ func (m *MongoSelectivePump) ensureIndexes(c *mgo.Collection) error {
 		return err
 	}
 
-	orgIndex := mgo.Index{
-		Key:        []string{"orgid"},
+	logBrowserIndex := mgo.Index{
+		Key:        []string{"-timestamp", "apiid", "apikey", "responsecode"},
 		Background: true,
 	}
 
-	err = c.EnsureIndex(orgIndex)
+	err = c.EnsureIndex(logBrowserIndex)
 	if err != nil {
 		return err
 	}
 
-	idOrgIndex := mgo.Index{
-		Key:        []string{"_id", "orgid"},
-		Background: true,
-	}
-
-	err = c.EnsureIndex(idOrgIndex)
-	if err != nil {
-		return err
-	}
-
-	idOrgApiIndex := mgo.Index{
-		Key:        []string{"_id", "orgid", "apiid"},
-		Background: true,
-	}
-
-	err = c.EnsureIndex(idOrgApiIndex)
-	if err != nil {
-		return err
-	}
-
-	idOrgErrIndex := mgo.Index{
-		Key:        []string{"_id", "orgid", "responsecode"},
-		Background: true,
-	}
-
-	return c.EnsureIndex(idOrgErrIndex)
+	return nil
 }
 
 func (m *MongoSelectivePump) WriteData(data []interface{}) error {


### PR DESCRIPTION
MongoDB collections for analytics (both generic and selective) lack indices that make querying them (e.g. with the dashboard log browser) efficient. This adds a composite index that would work in most cases as well as by-orgid and by-apiid indices for the generic collection. It also removes the ones that don't make much sense: an orgid index for selective collections, which are already naturally per-org, composite indices that start with `_id` and thus never really utilised.

In general this would significantly increase dashboard log browser performance for large collections (multiple GB and larger), lower the load on MongoDB itself when performing related queries. At the same time removing unused indices decreases the storage requirements somewhat.

Related to #74.