### PR TITLE
adding logzio dependencies to vendor

### DIFF
--- a/vendor/github.com/logzio/logzio-go/LICENSE
+++ b/vendor/github.com/logzio/logzio-go/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/logzio/logzio-go/README.md
+++ b/vendor/github.com/logzio/logzio-go/README.md
@@ -1,0 +1,114 @@
+# Logzio Golang API client
+
+Sends logs to [logz.io](https://logz.io) over HTTP. It is a low level lib that can to be integrated with other logging libs.
+
+[![GoDoc][doc-img]][doc] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] [![Go Report][report-img]][report]
+
+## Prerequisites
+go 1.x
+
+## Installation
+```shell
+$ go get -u github.com/logzio/logzio-go
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/logzio/logzio-go"
+    "os"
+    "time"
+)
+
+func main() {
+  l, err := logzio.New(
+  		"fake-token",
+  		SetDebug(os.Stderr),
+  		SetUrl("http://localhost:12345"),
+  		SetDrainDuration(time.Minute*10),
+        SetSetTempDirectory("myQueue"),
+        SetDrainDiskThreshold(99)
+  	) // token is required
+  if err != nil {
+    panic(err)
+  }
+  msg := fmt.Sprintf("{ \"%s\": \"%s\"}", "message", time.Now().UnixNano())
+
+  err = l.Send([]byte(msg))
+  if err != nil {
+     panic(err)
+  }
+
+  l.Stop() //logs are buffered on disk. Stop will drain the buffer
+}
+```
+
+## Usage
+
+- Set url mode:
+    `logzio.New(token, SetUrl(ts.URL))`
+
+- Set drain duration (flush logs on disk):
+    `logzio.New(token, SetDrainDuration(time.Hour))`
+
+- Set debug mode:
+    `logzio.New(token, SetDebug(os.Stderr))`
+
+- Set queue dir:
+    `logzio.New(token, SetSetTempDirectory(os.Stderr))`
+
+- Set the sender to check if it crosses the maximum allowed disk usage:
+    `logzio.New(token, SetCheckDiskSpace(true))`
+
+- Set disk queue threshold, once the threshold is crossed the sender will not enqueue the received logs:
+    `logzio.New(token, SetDrainDiskThreshold(99))`
+
+## Disk queue
+
+Logzio go client uses [goleveldb](https://github.com/syndtr/goleveldb) and [goqueue](github.com/beeker1121/goque) as a persistent storage.
+Every 5 seconds logs are sent to logz.io (if any are available)
+
+## Tests
+
+```shell
+$ go test -v
+
+```
+
+
+See [travis.yaml](.travis.yml) for running benchmark tests
+
+
+## Contributing
+ All PRs are welcome
+
+## Authors
+
+* **Douglas Chimento**  - [dougEfresh][me]
+* **Ido Halevi**  - [idohalevi](https://github.com/idohalevi)
+
+
+## License
+
+This project is licensed under the Apache License - see the [LICENSE](LICENSE) file for details
+
+## Acknowledgments
+
+* [logzio-java-sender](https://github.com/logzio/logzio-java-sender)
+
+
+[doc-img]: https://godoc.org/github.com/dougEfresh/logzio-go?status.svg
+[doc]: https://godoc.org/github.com/dougEfresh/logzio-go
+[ci-img]: https://travis-ci.org/dougEfresh/logzio-go.svg?branch=master
+[ci]: https://travis-ci.org/dougEfresh/logzio-go
+[cov-img]: https://codecov.io/gh/dougEfresh/logzio-go/branch/master/graph/badge.svg
+[cov]: https://codecov.io/gh/dougEfresh/logzio-go
+[glide.lock]: https://github.com/uber-go/zap/blob/master/glide.lock
+[zap]: https://github.com/uber-go/zap
+[me]: https://github.com/dougEfresh
+[report-img]: https://goreportcard.com/badge/github.com/dougEfresh/logzio-go
+[report]: https://goreportcard.com/report/github.com/dougEfresh/logzio-go

--- a/vendor/github.com/logzio/logzio-go/logziosender.go
+++ b/vendor/github.com/logzio/logzio-go/logziosender.go
@@ -1,0 +1,338 @@
+// Copyright © 2017 Douglas Chimento <dchimento@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logzio
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/beeker1121/goque"
+	"github.com/ricochet2200/go-disk-usage/du"
+	"go.uber.org/atomic"
+)
+
+const (
+	maxSize             = 3 * 1024 * 1024 // 3 mb
+	sendSleepingBackoff = time.Second * 2
+	sendRetries         = 4
+	respReadLimit       = int64(4096)
+
+	defaultHost           = "https://listener.logz.io:8071"
+	defaultDrainDuration  = 5 * time.Second
+	defaultDiskThreshold  = 70.0 // represent % of the disk
+	defaultCheckDiskSpace = true
+
+	httpError = -1
+)
+
+// LogzioSender instance of the
+type LogzioSender struct {
+	queue             *goque.Queue
+	drainDuration     time.Duration
+	buf               *bytes.Buffer
+	draining          atomic.Bool
+	mux               sync.Mutex
+	token             string
+	url               string
+	debug             io.Writer
+	diskThreshold     float32
+	checkDiskSpace    bool
+	fullDisk          bool
+	checkDiskDuration time.Duration
+	dir               string
+	httpClient        *http.Client
+	httpTransport     *http.Transport
+}
+
+// Sender Alias to LogzioSender
+type Sender LogzioSender
+
+// SenderOptionFunc options for logz
+type SenderOptionFunc func(*LogzioSender) error
+
+// New creates a new Logzio sender with a token and options
+func New(token string, options ...SenderOptionFunc) (*LogzioSender, error) {
+	l := &LogzioSender{
+		buf:               bytes.NewBuffer(make([]byte, maxSize)),
+		drainDuration:     defaultDrainDuration,
+		url:               fmt.Sprintf("%s/?token=%s", defaultHost, token),
+		token:             token,
+		dir:               fmt.Sprintf("%s%s%s%s%d", os.TempDir(), string(os.PathSeparator), "logzio-buffer", string(os.PathSeparator), time.Now().UnixNano()),
+		diskThreshold:     defaultDiskThreshold,
+		checkDiskSpace:    defaultCheckDiskSpace,
+		fullDisk:          false,
+		checkDiskDuration: 5 * time.Second,
+	}
+
+	tlsConfig := &tls.Config{}
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
+	}
+	// in case server side is sleeping - wait 10s instead of waiting for him to wake up
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   time.Second * 10,
+	}
+	l.httpClient = client
+	l.httpTransport = transport
+
+	for _, option := range options {
+		if err := option(l); err != nil {
+			return nil, err
+		}
+	}
+
+	q, err := goque.OpenQueue(l.dir)
+	if err != nil {
+		return nil, err
+	}
+
+	l.queue = q
+	go l.start()
+	go l.isEnoughDiskSpace()
+	return l, nil
+}
+
+// SetTempDirectory Use this temporary dir
+func SetTempDirectory(dir string) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.dir = dir
+		return nil
+	}
+}
+
+// SetUrl set the url which maybe different from the defaultUrl
+func SetUrl(url string) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.url = fmt.Sprintf("%s/?token=%s", url, l.token)
+		l.debugLog("logziosender.go: Setting url to %s\n", l.url)
+		return nil
+	}
+}
+
+// SetDebug mode and send logs to this writer
+func SetDebug(debug io.Writer) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.debug = debug
+		return nil
+	}
+}
+
+// SetDrainDuration to change the interval between drains
+func SetDrainDuration(duration time.Duration) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.drainDuration = duration
+		return nil
+	}
+}
+
+// SetDrainDiskThreshold to change the maximum used disk space
+func SetCheckDiskSpace(check bool) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.checkDiskSpace = check
+		return nil
+	}
+}
+
+// SetDrainDiskThreshold to change the maximum used disk space
+func SetDrainDiskThreshold(th int) SenderOptionFunc {
+	return func(l *LogzioSender) error {
+		l.diskThreshold = float32(th)
+		return nil
+	}
+}
+
+func (l *LogzioSender) isEnoughDiskSpace() bool {
+	for {
+		<-time.After(l.checkDiskDuration)
+		if l.checkDiskSpace {
+			usage := du.NewDiskUsage(l.dir)
+			if usage.Usage()*100 > l.diskThreshold {
+				l.debugLog("Logz.io: Dropping logs, as FS used space on %s is %g percent,"+
+					" and the drop threshold is %g percent\n",
+					l.dir, usage.Usage()*100, l.diskThreshold)
+				l.fullDisk = true
+			} else {
+				l.fullDisk = false
+			}
+		} else {
+			l.fullDisk = false
+		}
+	}
+}
+
+// Send the payload to logz.io
+func (l *LogzioSender) Send(payload []byte) error {
+	if !l.fullDisk {
+		_, err := l.queue.Enqueue(payload)
+		return err
+	}
+	return nil
+}
+
+func (l *LogzioSender) start() {
+	l.drainTimer()
+}
+
+// Stop will close the LevelDB queue and do a final drain
+func (l *LogzioSender) Stop() {
+	defer l.queue.Close()
+	l.Drain()
+
+}
+
+func (l *LogzioSender) tryToSendLogs() int {
+	resp, err := l.httpClient.Post(l.url, "text/plain", l.buf)
+	if err != nil {
+		l.debugLog("logziosender.go: Error sending logs to %s %s\n", l.url, err)
+		return httpError
+	}
+
+	defer resp.Body.Close()
+	statusCode := resp.StatusCode
+
+	_, err = io.Copy(ioutil.Discard, io.LimitReader(resp.Body, respReadLimit))
+	if err != nil {
+		l.debugLog("Error reading response body: %v", err)
+	}
+	return statusCode
+}
+
+func (l *LogzioSender) drainTimer() {
+	for {
+		time.Sleep(l.drainDuration)
+		l.Drain()
+	}
+}
+
+func (l *LogzioSender) shouldRetry(attempt int, statusCode int) bool {
+	retry := true
+	switch statusCode {
+	case http.StatusBadRequest:
+		retry = false
+	case http.StatusUnauthorized:
+		retry = false
+	case http.StatusOK:
+		retry = false
+	}
+
+	if !retry && statusCode != http.StatusOK {
+		l.requeue()
+	} else if retry && attempt == (sendRetries-1) {
+		l.requeue()
+	}
+	return retry
+}
+
+// Drain - Send remaining logs
+func (l *LogzioSender) Drain() {
+	if l.draining.Load() {
+		l.debugLog("logziosender.go: Already draining\n")
+		return
+	}
+	l.mux.Lock()
+	l.debugLog("logziosender.go: draining queue\n")
+	defer l.mux.Unlock()
+	l.draining.Toggle()
+	defer l.draining.Toggle()
+
+	l.buf.Reset()
+	bufSize := l.dequeueUpToMaxBatchSize()
+	if bufSize > 0 {
+		backOff := sendSleepingBackoff
+		toBackOff := false
+		for attempt := 0; attempt < sendRetries; attempt++ {
+			if toBackOff {
+				l.debugLog("logziosender.go: failed to send logs, trying again in %v\n", backOff)
+				time.Sleep(backOff)
+				backOff *= 2
+			}
+			statusCode := l.tryToSendLogs()
+			if l.shouldRetry(attempt, statusCode) {
+				toBackOff = true
+			} else {
+				break
+			}
+		}
+	}
+}
+
+func (l *LogzioSender) dequeueUpToMaxBatchSize() int {
+	var (
+		bufSize int
+		err     error
+	)
+	for bufSize < maxSize && err == nil {
+		item, err := l.queue.Dequeue()
+		if err != nil {
+			l.debugLog("queue state: %s\n", err)
+		}
+		if item != nil {
+			// NewLine is appended tp item.Value
+			if len(item.Value)+bufSize+1 > maxSize {
+				break
+			}
+			bufSize += len(item.Value)
+			l.debugLog("logziosender.go: Adding item %d with size %d (total buffSize: %d)\n",
+				item.ID, len(item.Value), bufSize)
+			_, err := l.buf.Write(append(item.Value, '\n'))
+			if err != nil {
+				l.errorLog("error writing to buffer %s", err)
+			}
+		} else {
+			break
+		}
+	}
+	return bufSize
+}
+
+// Sync drains the queue
+func (l *LogzioSender) Sync() error {
+	l.Drain()
+	return nil
+}
+
+func (l *LogzioSender) requeue() {
+	l.debugLog("logziosender.go: Requeue %s", l.buf.String())
+	err := l.Send(l.buf.Bytes())
+	if err != nil {
+		l.errorLog("could not requeue logs %s", err)
+	}
+}
+
+func (l *LogzioSender) debugLog(format string, a ...interface{}) {
+	if l.debug != nil {
+		fmt.Fprintf(l.debug, format, a...)
+	}
+}
+
+func (l *LogzioSender) errorLog(format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, a...)
+}
+
+func (l *LogzioSender) Write(p []byte) (n int, err error) {
+	return len(p), l.Send(p)
+}
+
+func (l *LogzioSender) CloseIdleConnections() {
+	l.httpTransport.CloseIdleConnections()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -211,6 +211,12 @@
 			"revisionTime": "2018-10-04T22:41:46Z"
 		},
 		{
+			"checksumSHA1": "Yhz9ldurKeGAb1PU4GNo6J3zStM=",
+			"path": "github.com/logzio/logzio-go",
+			"revision": "1138f714b3b673ecb3afec265088f65d45479079",
+			"revisionTime": "2019-03-31T10:01:43Z"
+		},
+		{
 			"checksumSHA1": "Zgi7LCXXiFQYL84rwInvfJHEOQM=",
 			"origin": "github.com/TykTechnologies/tyk/vendor/github.com/lonelycode/go-uuid/uuid",
 			"path": "github.com/lonelycode/go-uuid/uuid",


### PR DESCRIPTION
```
pumps/logzio.go:11:2: cannot find package "github.com/logzio/logzio-go" in any of:
        /Users/ahmet/go/src/github.com/TykTechnologies/tyk-pump/vendor/github.com/logzio/logzio-go (vendor tree)
        /usr/local/go/src/github.com/logzio/logzio-go (from $GOROOT)
        /Users/ahmet/go/src/github.com/logzio/logzio-go (from $GOPATH)
```