### PR TITLE
Added new fields  in aggregate collection

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -286,7 +286,7 @@ func doHash(in string) string {
 }
 
 // AggregateData calculates aggregated data, returns map orgID => aggregated analytics data
-func AggregateData(data []interface{}) map[string]AnalyticsRecordAggregate {
+func AggregateData(data []interface{}, trackAllPaths bool) map[string]AnalyticsRecordAggregate {
 	analyticsPerOrg := make(map[string]AnalyticsRecordAggregate)
 
 	for _, v := range data {
@@ -341,6 +341,10 @@ func AggregateData(data []interface{}) map[string]AnalyticsRecordAggregate {
 		if (thisV.ResponseCode < 300) && (thisV.ResponseCode >= 200) {
 			thisCounter.Success = 1
 			thisAggregate.Total.Success++
+		}
+
+		if trackAllPaths {
+			thisV.TrackPath = true
 		}
 
 		// Convert to a map (for easy iteration)

--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -388,18 +388,21 @@ func AggregateData(data []interface{}) map[string]AnalyticsRecordAggregate {
 					thisAggregate.APIKeys[value.(string)].Identifier = value.(string)
 					thisAggregate.APIKeys[value.(string)].HumanIdentifier = thisV.Alias
 
-					keyStr := doHash(thisV.APIID + ":" + thisV.Path)
-					data := thisAggregate.KeyEndpoint[value.(string)]
+					if thisV.TrackPath {
+						keyStr := doHash(thisV.APIID + ":" + thisV.Path)
+						data := thisAggregate.KeyEndpoint[value.(string)]
 
-					if data == nil {
-						data = make(map[string]*Counter)
+						if data == nil {
+							data = make(map[string]*Counter)
+						}
+
+						c = IncrementOrSetUnit(data[keyStr])
+						c.Identifier = keyStr
+						c.HumanIdentifier = keyStr
+						data[keyStr] = c
+						thisAggregate.KeyEndpoint[value.(string)] = data
+
 					}
-
-					c = IncrementOrSetUnit(data[keyStr])
-					c.Identifier = keyStr
-					c.HumanIdentifier = keyStr
-					data[keyStr] = c
-					thisAggregate.KeyEndpoint[value.(string)] = data
 				}
 				break
 			case "OauthID":

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -38,7 +38,8 @@ var (
 
 // HybridPump allows to send analytics to MDCB over RPC
 type HybridPump struct {
-	aggregated bool
+	aggregated    bool
+	trackAllPaths bool
 }
 
 func (p *HybridPump) GetName() string {
@@ -110,6 +111,12 @@ func (p *HybridPump) Init(config interface{}) error {
 		p.aggregated = aggregated.(bool)
 	}
 
+	if p.aggregated {
+		if trackAllPaths, ok := meta["track_all_paths"]; ok {
+			p.trackAllPaths = trackAllPaths.(bool)
+		}
+	}
+
 	return nil
 }
 
@@ -144,7 +151,7 @@ func (p *HybridPump) WriteData(data []interface{}) error {
 		}
 	} else { // send aggregated data
 		// calculate aggregates
-		aggregates := analytics.AggregateData(data)
+		aggregates := analytics.AggregateData(data, p.trackAllPaths)
 
 		// turn map with analytics aggregates into JSON payload
 		jsonData, err := json.Marshal(aggregates)

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -28,6 +28,7 @@ type MongoAggregateConf struct {
 	MongoUseSSL                bool   `mapstructure:"mongo_use_ssl"`
 	MongoSSLInsecureSkipVerify bool   `mapstructure:"mongo_ssl_insecure_skip_verify"`
 	UseMixedCollection         bool   `mapstructure:"use_mixed_collection"`
+	TrackAllPaths              bool   `mapstructure:"track_all_paths"`
 }
 
 func (m *MongoAggregatePump) New() Pump {
@@ -142,7 +143,7 @@ func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 		m.WriteData(data)
 	} else {
 		// calculate aggregates
-		analyticsPerOrg := analytics.AggregateData(data)
+		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths)
 
 		// put aggregated data into MongoDB
 		for orgID, filteredData := range analyticsPerOrg {


### PR DESCRIPTION
Added new field `track_all_paths` in configuration of Mongodb Aggregate and Hybrid Pump.

Also, new fields are added in collection of aggregate logs:

1. `keyendpoints`
2. `lists.keyendpoints`
3. `oauthendpoints`
4. `lists.oauthendpoints`

It will store data only for **tracked endpoints**. To store data for all endpoints, set  `track_all_paths` field to true. 

Format of data is as follows
```json
"keyendpoints/oauthendpoints":{
         "keyId/oauthId":{
               "Base64(APIID:Endpoint)":{
                "errortotal" : 0,
                "hits" : 1,
                "humanidentifier" : "Base64(APIID:Endpoint)",
                "identifier" : "Base64(APIID:Endpoint)",
                "lasttime" : "2019-07-15T07:18:22.708Z",
                "success" : 1,
                "totalrequesttime" : 292.0,
                "requesttime" : 292.0
                }
         }
}

"lists.keyendpoints/lists.oauthendpoints":{
          "keyId/oauthId":[
                {
                "errortotal" : 0,
                "hits" : 1,
                "humanidentifier" : "Base64(APIID:Endpoint)",
                "identifier" : "Base64(APIID:Endpoint)",
                "lasttime" : "2019-07-15T07:18:22.708Z",
                "success" : 1,
                "totalrequesttime" : 292.0,
                "requesttime" : 292.0
                },
         ]
}
```
This will help to generate analytics for below unique combinations
1. Key+API+Path
2. Key+API
3. Oauth+API+Path
4. Oauth+API