### PR TITLE
Change name to type in sample and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Create a `pump.conf` file:
       }
     },
     "mongo-pump-aggregate": {
-      "name": "mongo-pump-aggregate",
+      "type": "mongo-pump-aggregate",
       "meta": {
 	"mongo_url": "mongodb://username:password@{hostname:port},{hostname:port}/{db_name}",
 	"use_mixed_collection": true
@@ -142,7 +142,7 @@ Create a `pump.conf` file:
       }
     },
     "dogstatsd": {
-      "name": "dogstatsd",
+      "type": "dogstatsd",
       "meta": {
         "address": "localhost:8125",
         "namespace": "pump",
@@ -259,7 +259,7 @@ Prometheus is an open-source monitoring system with a dimensional data model, fl
 Add the following section to expose "/metrics" endpoint:
 ```
 "prometheus": {
-        "type": "prometheus",
+  "type": "prometheus",
 	"meta": {
 		"listen_address": "localhost:9090",
 		"path": "/metrics"
@@ -286,9 +286,9 @@ And the following Histogram for latencies:
 - `buffered_max_messages`: Max messages in single datagram if `buffered: true`. Default 16
 - `sample_rate`: default 1 which equates to 100% of requests. To sample at 50%, set to 0.5
 
-```json
+```.json
 "dogstatsd": {
-  "name": "dogstatsd",
+  "type": "dogstatsd",
   "meta": {
     "address": "localhost:8125",
     "namespace": "pump",

--- a/pump.example.conf
+++ b/pump.example.conf
@@ -15,7 +15,7 @@
   "purge_delay": 10,
   "pumps": {
     "mongo": {
-      "name": "mongo",
+      "type": "mongo",
       "meta": {
         "collection_name": "tyk_analytics",
         "mongo_url": "mongodb://localhost/tyk_analytics",
@@ -24,7 +24,7 @@
       }
     },
     "kafka": {
-      "name": "kafka",
+      "type": "kafka",
       "meta": {
         "broker": [
             "localhost:9092"
@@ -39,21 +39,21 @@
       }
     },
     "mongo-pump-aggregate": {
-      "name": "mongo-pump-aggregate",
+      "type": "mongo-pump-aggregate",
       "meta": {
         "mongo_url": "mongodb://localhost/tyk_analytics",
         "use_mixed_collection": true
       }
     },
     "prometheus": {
-      "name": "prometheus",
+      "type": "prometheus",
       "meta": {
         "path": "/metrics",
         "listen_address": ":9090"
       }
     },
     "dogstatsd": {
-      "name": "dogstatsd",
+      "type": "dogstatsd",
       "meta": {
         "address": "localhost:8125",
         "namespace": "pump",


### PR DESCRIPTION
As `name` has been deprecated, have changed all mentions to `type`.