### PR TITLE
Restore lists data in aggregate mixed collection

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -47,6 +47,18 @@ type AnalyticsRecordAggregate struct {
 
 	Endpoints map[string]*Counter
 
+	Lists struct {
+		APIKeys       []Counter
+		APIID         []Counter
+		OauthIDs      []Counter
+		Geo           []Counter
+		Tags          []Counter
+		Errors        []Counter
+		Endpoints     []Counter
+		KeyEndpoint   map[string][]Counter `bson:"keyendpoints"`
+		OauthEndpoint map[string][]Counter `bson:"oauthendpoints"`
+	}
+
 	KeyEndpoint   map[string]map[string]*Counter `bson:"keyendpoints"`
 	OauthEndpoint map[string]map[string]*Counter `bson:"oauthendpoints"`
 


### PR DESCRIPTION
Fixes #135 
PR #120 removed `Lists` field from `AnalyticsRecordAggregate` structure. 
Because of this lists data was not getting pushed to the mixed aggregate collection, which are used to generate the listing