### PR TITLE
Fix influx pump write loop duplication

### DIFF
--- a/pumps/influx.go
+++ b/pumps/influx.go
@@ -140,9 +140,10 @@ func (i *InfluxPump) WriteData(data []interface{}) error {
 
 		// Add point to batch point
 		bp.AddPoint(pt)
-		// Write the batch
-		c.Write(bp)
 	}
+
+	// Now that all points are added, write the batch
+	c.Write(bp)
 
 	return nil
 }


### PR DESCRIPTION
Devs at our company noticed that the influx pump was SUPER slow on doing writes when you have larger amounts of data.  Digging in a bit we've located a small bug that causes a big problem.  In the `WriteData` function the incoming records are processed to send out to influx, but instead of waiting until all records have been processed and then sending a write, the `Write` got accidentally put inside the loop.

Say you have 5000 records incoming in a purge loop, that would end up sending 5000 separate POSTS to influx.  The first post would have 1 record, the second would have 2, etc.  After fixing this the influx writes got very fast.