### PR TITLE
Add option to obfuscate keys when writing to splunk

### DIFF
--- a/pumps/splunk.go
+++ b/pumps/splunk.go
@@ -144,10 +144,10 @@ func (p *SplunkPump) WriteData(data []interface{}) error {
 		apiKey := decoded.APIKey
 		if p.config.ObfuscateAPIKeys {
 			if len(apiKey) > 4 {
-				apiKey = "****" + keyName[len(apiKey)-4:]
+				apiKey = "****" + apiKey[len(apiKey)-4:]
 			}
 		}
-		
+
 		event := map[string]interface{}{
 			"method":        decoded.Method,
 			"path":          decoded.Path,

--- a/pumps/splunk.go
+++ b/pumps/splunk.go
@@ -99,6 +99,7 @@ type SplunkPumpConfig struct {
 	SSLCertFile           string `mapstructure:"ssl_cert_file"`
 	SSLKeyFile            string `mapstructure:"ssl_key_file"`
 	SSLServerName         string `mapstructure:"ssl_server_name"`
+	ObfuscateAPIKeys      bool   `mapstructure:"obfuscate_api_keys"`
 }
 
 // New initializes a new pump.
@@ -140,11 +141,18 @@ func (p *SplunkPump) WriteData(data []interface{}) error {
 	}).Info("Writing ", len(data), " records")
 	for _, v := range data {
 		decoded := v.(analytics.AnalyticsRecord)
+		apiKey := decoded.APIKey
+		if p.config.ObfuscateAPIKeys {
+			if len(apiKey) > 4 {
+				apiKey = "****" + keyName[len(apiKey)-4:]
+			}
+		}
+		
 		event := map[string]interface{}{
 			"method":        decoded.Method,
 			"path":          decoded.Path,
 			"response_code": decoded.ResponseCode,
-			"api_key":       decoded.APIKey,
+			"api_key":       apiKey,
 			"time_stamp":    decoded.TimeStamp,
 			"api_version":   decoded.APIVersion,
 			"api_name":      decoded.APIName,


### PR DESCRIPTION
Splunk pump now has `obfuscate_api_keys` option