### PR TITLE
Fixed in Elasticsearch analytics to publish the alias

### DIFF
--- a/pumps/elasticsearch.go
+++ b/pumps/elasticsearch.go
@@ -194,6 +194,7 @@ func getMapping(datum analytics.AnalyticsRecord, extendedStatistics bool) map[st
 		"org_id":          record.OrgID,
 		"oauth_id":        record.OauthID,
 		"request_time_ms": record.RequestTime,
+		"alias":           record.Alias,
 	}
 
 	if extendedStatistics {


### PR DESCRIPTION
This PR is for publishing the alias into the Elasticsearch. We can use the alias for different purposes such as identifying the users in the analytics.
 [Github issue](https://github.com/TykTechnologies/tyk-pump/issues/38) and [community forum ](https://community.tyk.io/t/user-identifier-in-analytic-logs/1621/3) are described this issue. 