### PR TITLE
Reduce log noises from mongo aggregate pump

### DIFF
--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -133,7 +133,7 @@ func (m *MongoAggregatePump) ensureIndexes(c *mgo.Collection) error {
 func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 	log.WithFields(logrus.Fields{
 		"prefix": analytics.MongoAggregatePrefix,
-	}).Info("Writing ", len(data), " records")
+	}).Debug("Writing ", len(data), " records")
 
 	if m.dbSession == nil {
 		log.WithFields(logrus.Fields{


### PR DESCRIPTION
This changes log in mongo aggregate pump to use Debug.

It is unnecessary noisy with debug information