### PR TITLE
Store latency information

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -18,6 +18,11 @@ type NetworkStats struct {
 	BytesOut         int64
 }
 
+type Latency struct {
+	Total    int64
+	Upstream int64
+}
+
 // AnalyticsRecord encodes the details of a request
 type AnalyticsRecord struct {
 	Method        string
@@ -44,6 +49,7 @@ type AnalyticsRecord struct {
 	IPAddress     string
 	Geo           GeoData
 	Network       NetworkStats
+	Latency       Latency
 	Tags          []string
 	Alias         string
 	TrackPath     bool


### PR DESCRIPTION
Fixes #151 

### - **New fields in **Analytics** collection**

1. **latency.upstream**: Records latency caused by the upstream
2. **latency.total**: Records total end-to-end latency

### - **New fields in Aggregate Analytics Counter**

1. **max_upstream_latency**: Records maximum upstream latency
2. **min_upstream_latency**: Records minimum upstream latency
3. **total_upstream_latency**: Records total upstream latency
4. **max_latency**: Records maximum end-to-end latency
5. **min_latency**: Records minimum end-to-end latency
6. **total_latency**: Records total end-to-end latency
7. **latency**: Avg latency
8. **upstream_latency**: Avg upstream latency