### PR TITLE
Add config option to ignore tags with common prefix

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -353,8 +353,18 @@ func doHash(in string) string {
 	return search
 }
 
+func ignoreTag(tag string, ignoreTagPrefixList []string) bool {
+	for _, prefix := range ignoreTagPrefixList {
+		if strings.HasPrefix(tag, prefix) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // AggregateData calculates aggregated data, returns map orgID => aggregated analytics data
-func AggregateData(data []interface{}, trackAllPaths bool) map[string]AnalyticsRecordAggregate {
+func AggregateData(data []interface{}, trackAllPaths bool, ignoreTagPrefixList []string) map[string]AnalyticsRecordAggregate {
 	analyticsPerOrg := make(map[string]AnalyticsRecordAggregate)
 
 	for _, v := range data {
@@ -597,12 +607,15 @@ func AggregateData(data []interface{}, trackAllPaths bool) map[string]AnalyticsR
 						thisAggregate.Geo[thisV.Geo.Country.ISOCode].HumanIdentifier = thisV.Geo.Country.ISOCode
 					}
 					break
+
 				case "Tags":
 					for _, thisTag := range thisV.Tags {
-						c := IncrementOrSetUnit(thisAggregate.Tags[thisTag])
-						thisAggregate.Tags[thisTag] = c
-						thisAggregate.Tags[thisTag].Identifier = thisTag
-						thisAggregate.Tags[thisTag].HumanIdentifier = thisTag
+						if !ignoreTag(thisTag, ignoreTagPrefixList) {
+							c := IncrementOrSetUnit(thisAggregate.Tags[thisTag])
+							thisAggregate.Tags[thisTag] = c
+							thisAggregate.Tags[thisTag].Identifier = thisTag
+							thisAggregate.Tags[thisTag].HumanIdentifier = thisTag
+						}
 					}
 					break
 

--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -354,6 +354,11 @@ func doHash(in string) string {
 }
 
 func ignoreTag(tag string, ignoreTagPrefixList []string) bool {
+	// ignore tag added for key by gateway
+	if strings.HasPrefix(tag, "key-") {
+		return true
+	}
+
 	for _, prefix := range ignoreTagPrefixList {
 		if strings.HasPrefix(tag, prefix) {
 			return true

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -2,6 +2,7 @@ package pumps
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 
@@ -116,6 +117,15 @@ func (p *HybridPump) Init(config interface{}) error {
 		if trackAllPaths, ok := meta["track_all_paths"]; ok {
 			p.trackAllPaths = trackAllPaths.(bool)
 		}
+
+		if list, ok := meta["ignore_tag_prefix_list"]; ok {
+			ignoreTagPrefixList := list.([]interface{})
+			p.ignoreTagPrefixList = make([]string, len(ignoreTagPrefixList))
+			for k, v := range ignoreTagPrefixList {
+				p.ignoreTagPrefixList[k] = fmt.Sprint(v)
+			}
+		}
+
 	}
 
 	return nil

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -38,8 +38,9 @@ var (
 
 // HybridPump allows to send analytics to MDCB over RPC
 type HybridPump struct {
-	aggregated    bool
-	trackAllPaths bool
+	aggregated          bool
+	trackAllPaths       bool
+	ignoreTagPrefixList []string
 }
 
 func (p *HybridPump) GetName() string {
@@ -151,7 +152,7 @@ func (p *HybridPump) WriteData(data []interface{}) error {
 		}
 	} else { // send aggregated data
 		// calculate aggregates
-		aggregates := analytics.AggregateData(data, p.trackAllPaths)
+		aggregates := analytics.AggregateData(data, p.trackAllPaths, p.ignoreTagPrefixList)
 
 		// turn map with analytics aggregates into JSON payload
 		jsonData, err := json.Marshal(aggregates)

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -271,7 +271,7 @@ func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 			withTimeUpdate := analytics.AnalyticsRecordAggregate{}
 			_, avgErr := analyticsCollection.Find(query).Apply(avgChange, &withTimeUpdate)
 
-			if len(withTimeUpdate.Tags) > m.dbConf.ThresholdLenTagList {
+			if m.dbConf.ThresholdLenTagList != -1 && (len(withTimeUpdate.Tags) > m.dbConf.ThresholdLenTagList) {
 				printAlert(withTimeUpdate, m.dbConf.ThresholdLenTagList)
 			}
 

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -100,7 +100,7 @@ func printAlert(doc analytics.AnalyticsRecordAggregate) {
 		l = COMMON_TAGS_COUNT
 	}
 
-	log.Warnf("WARNING: Found more that %v tag entries per record, which may cause performance issues with aggregate logs. List of most common tag-prefix: %v. You can ignore these tags using ignore_tag_prefix_list option", MAX_TAGS_LEN, listOfCommonPrefix[:l])
+	log.Warnf("WARNING: Found more that %v tag entries per document, which may cause performance issues with aggregate logs. List of most common tag-prefix: %v. You can ignore these tags using ignore_tag_prefix_list option", MAX_TAGS_LEN, listOfCommonPrefix[:l])
 }
 
 func (m *MongoAggregatePump) doHash(in string) string {

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -24,11 +24,12 @@ type MongoAggregatePump struct {
 }
 
 type MongoAggregateConf struct {
-	MongoURL                   string `mapstructure:"mongo_url"`
-	MongoUseSSL                bool   `mapstructure:"mongo_use_ssl"`
-	MongoSSLInsecureSkipVerify bool   `mapstructure:"mongo_ssl_insecure_skip_verify"`
-	UseMixedCollection         bool   `mapstructure:"use_mixed_collection"`
-	TrackAllPaths              bool   `mapstructure:"track_all_paths"`
+	MongoURL                   string   `mapstructure:"mongo_url"`
+	MongoUseSSL                bool     `mapstructure:"mongo_use_ssl"`
+	MongoSSLInsecureSkipVerify bool     `mapstructure:"mongo_ssl_insecure_skip_verify"`
+	UseMixedCollection         bool     `mapstructure:"use_mixed_collection"`
+	TrackAllPaths              bool     `mapstructure:"track_all_paths"`
+	IgnoreTagPrefixList        []string `mapstructure:"ignore_tag_prefix_list"`
 }
 
 func (m *MongoAggregatePump) New() Pump {
@@ -143,7 +144,7 @@ func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 		m.WriteData(data)
 	} else {
 		// calculate aggregates
-		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths)
+		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths, m.dbConf.IgnoreTagPrefixList)
 
 		// put aggregated data into MongoDB
 		for orgID, filteredData := range analyticsPerOrg {

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -3,6 +3,7 @@ package pumps
 import (
 	b64 "encoding/base64"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
@@ -17,6 +18,8 @@ import (
 )
 
 var mongoAggregatePumpPrefix = "PMP_MONGOAGG"
+var MAX_TAGS_LEN = 1000
+var COMMON_TAGS_COUNT = 5
 
 type MongoAggregatePump struct {
 	dbSession *mgo.Session
@@ -35,6 +38,69 @@ type MongoAggregateConf struct {
 func (m *MongoAggregatePump) New() Pump {
 	newPump := MongoAggregatePump{}
 	return &newPump
+}
+
+func getListOfCommonPrefix(list []string) []string {
+	count := make(map[string]int)
+	result := make([]string, 0)
+	length := len(list)
+
+	if length == 0 || length == 1 {
+		return list
+	}
+
+	for i := 0; i < length-1; i++ {
+		for j := i + 1; j < length; j++ {
+			var prefLen int
+			str1 := list[i]
+			str2 := list[j]
+
+			if len(str1) > len(str2) {
+				prefLen = len(str2)
+			} else {
+				prefLen = len(str1)
+			}
+
+			k := 0
+			for k = 0; k < prefLen; k++ {
+				if str1[k] != str2[k] {
+					if k != 0 {
+						count[str1[:k]]++
+					}
+					break
+				}
+			}
+			if k == prefLen {
+				count[str1[:prefLen]]++
+			}
+		}
+	}
+
+	for k, _ := range count {
+		result = append(result, k)
+	}
+
+	sort.Slice(result, func(i, j int) bool { return count[result[i]] > count[result[j]] })
+
+	return result
+}
+
+func printAlert(doc analytics.AnalyticsRecordAggregate) {
+	var listofTags []string
+
+	for k, _ := range doc.Tags {
+		listofTags = append(listofTags, k)
+	}
+
+	listOfCommonPrefix := getListOfCommonPrefix(listofTags)
+
+	// list 5 common tag prefix
+	l := len(listOfCommonPrefix)
+	if l > COMMON_TAGS_COUNT {
+		l = COMMON_TAGS_COUNT
+	}
+
+	log.Warnf("WARNING: Found more that %v tag entries per record, which may cause performance issues with aggregate logs. List of most common tag-prefix: %v. You can ignore these tags using ignore_tag_prefix_list option", MAX_TAGS_LEN, listOfCommonPrefix[:l])
 }
 
 func (m *MongoAggregatePump) doHash(in string) string {
@@ -199,6 +265,10 @@ func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 			}
 			withTimeUpdate := analytics.AnalyticsRecordAggregate{}
 			_, avgErr := analyticsCollection.Find(query).Apply(avgChange, &withTimeUpdate)
+
+			if len(withTimeUpdate.Tags) > MAX_TAGS_LEN {
+				printAlert(withTimeUpdate)
+			}
 
 			if avgErr != nil {
 				log.WithFields(logrus.Fields{

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -77,7 +77,7 @@ func getListOfCommonPrefix(list []string) []string {
 		}
 	}
 
-	for k, _ := range count {
+	for k := range count {
 		result = append(result, k)
 	}
 
@@ -89,7 +89,7 @@ func getListOfCommonPrefix(list []string) []string {
 func printAlert(doc analytics.AnalyticsRecordAggregate, thresholdLenTagList int) {
 	var listofTags []string
 
-	for k, _ := range doc.Tags {
+	for k := range doc.Tags {
 		listofTags = append(listofTags, k)
 	}
 


### PR DESCRIPTION
Fixes #162 

Added additional config options:
1. `ignore_tag_prefix_list`( in mongo aggregate and hybrid pump.)
It will not store analytics for tags having prefix specified in the list.
**Note**: Prefix `key-` is added in the list by default. This tag is added by gateway for keys.

2. `threshold_len_tag_list`( in mongo aggregate pump)
If number of tags in a document grows beyond `threshold_len_tag_list`, pump will throw a warning. The warning will print top 5 common tag prefix. Default value is **1000**. To disable alerts set it to -1.
