### PR TITLE
Option to store analytics per minute

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -213,7 +213,7 @@ func (f *AnalyticsRecordAggregate) AsChange() bson.M {
 	newUpdate = f.generateBSONFromProperty("", "total", &f.Total, newUpdate)
 
 	asTime := f.TimeStamp
-	newTime := time.Date(asTime.Year(), asTime.Month(), asTime.Day(), asTime.Hour(), 0, 0, 0, asTime.Location())
+	newTime := time.Date(asTime.Year(), asTime.Month(), asTime.Day(), asTime.Hour(), asTime.Minute(), 0, 0, asTime.Location())
 	newUpdate["$set"].(bson.M)["timestamp"] = newTime
 	newUpdate["$set"].(bson.M)["expireAt"] = f.ExpireAt
 	newUpdate["$set"].(bson.M)["timeid.year"] = newTime.Year()
@@ -354,7 +354,7 @@ func doHash(in string) string {
 }
 
 // AggregateData calculates aggregated data, returns map orgID => aggregated analytics data
-func AggregateData(data []interface{}, trackAllPaths bool) map[string]AnalyticsRecordAggregate {
+func AggregateData(data []interface{}, trackAllPaths bool, storeAnalyticPerMinute bool) map[string]AnalyticsRecordAggregate {
 	analyticsPerOrg := make(map[string]AnalyticsRecordAggregate)
 
 	for _, v := range data {
@@ -372,7 +372,11 @@ func AggregateData(data []interface{}, trackAllPaths bool) map[string]AnalyticsR
 
 			// Set the hourly timestamp & expiry
 			asTime := thisV.TimeStamp
-			thisAggregate.TimeStamp = time.Date(asTime.Year(), asTime.Month(), asTime.Day(), asTime.Hour(), 0, 0, 0, asTime.Location())
+			if storeAnalyticPerMinute {
+				thisAggregate.TimeStamp = time.Date(asTime.Year(), asTime.Month(), asTime.Day(), asTime.Hour(), asTime.Minute(), 0, 0, asTime.Location())
+			} else {
+				thisAggregate.TimeStamp = time.Date(asTime.Year(), asTime.Month(), asTime.Day(), asTime.Hour(), 0, 0, 0, asTime.Location())
+			}
 			thisAggregate.ExpireAt = thisV.ExpireAt
 			thisAggregate.TimeID.Year = asTime.Year()
 			thisAggregate.TimeID.Month = int(asTime.Month())

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -38,8 +38,9 @@ var (
 
 // HybridPump allows to send analytics to MDCB over RPC
 type HybridPump struct {
-	aggregated    bool
-	trackAllPaths bool
+	aggregated             bool
+	trackAllPaths          bool
+	storeAnalyticPerMinute bool
 }
 
 func (p *HybridPump) GetName() string {
@@ -151,7 +152,7 @@ func (p *HybridPump) WriteData(data []interface{}) error {
 		}
 	} else { // send aggregated data
 		// calculate aggregates
-		aggregates := analytics.AggregateData(data, p.trackAllPaths)
+		aggregates := analytics.AggregateData(data, p.trackAllPaths, p.storeAnalyticPerMinute)
 
 		// turn map with analytics aggregates into JSON payload
 		jsonData, err := json.Marshal(aggregates)

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -121,7 +121,7 @@ func (p *HybridPump) Init(config interface{}) error {
 
 		if storeAnalyticPerMinute, ok := meta["store_analytics_per_minute"]; ok {
 			p.storeAnalyticPerMinute = storeAnalyticPerMinute.(bool)
-    }
+		}
 
 		if list, ok := meta["ignore_tag_prefix_list"]; ok {
 			ignoreTagPrefixList := list.([]interface{})

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -116,6 +116,11 @@ func (p *HybridPump) Init(config interface{}) error {
 		if trackAllPaths, ok := meta["track_all_paths"]; ok {
 			p.trackAllPaths = trackAllPaths.(bool)
 		}
+
+		if storeAnalyticPerMinute, ok := meta["store_analytics_per_minute"]; ok {
+			p.storeAnalyticPerMinute = storeAnalyticPerMinute.(bool)
+		}
+
 	}
 
 	return nil

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -29,6 +29,7 @@ type MongoAggregateConf struct {
 	MongoSSLInsecureSkipVerify bool   `mapstructure:"mongo_ssl_insecure_skip_verify"`
 	UseMixedCollection         bool   `mapstructure:"use_mixed_collection"`
 	TrackAllPaths              bool   `mapstructure:"track_all_paths"`
+	StoreAnalyticsPerMinute    bool   `mapstructure:"store_analytics_per_minute"`
 }
 
 func (m *MongoAggregatePump) New() Pump {
@@ -143,7 +144,7 @@ func (m *MongoAggregatePump) WriteData(data []interface{}) error {
 		m.WriteData(data)
 	} else {
 		// calculate aggregates
-		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths)
+		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths, m.dbConf.StoreAnalyticsPerMinute)
 
 		// put aggregated data into MongoDB
 		for orgID, filteredData := range analyticsPerOrg {


### PR DESCRIPTION
Fixes #164 
Added `store_analytics_per_minute` config option in aggregate and hybrid pumps.

Currently, we generate aggregate data per hour. If this option is enabled, aggregate data will be generated per minute.