### PR TITLE
Handle unsupported MongoDB characters

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -374,7 +374,7 @@ func replaceUnsupportedChars(path string) string {
 
 	if strings.Contains(path, ".") {
 		dotUnicode := fmt.Sprintf("\\u%x", ".")
-		result = strings.ReplaceAll(path, ".", dotUnicode)
+		result = strings.Replace(path, ".", dotUnicode, -1)
 	}
 
 	return result


### PR DESCRIPTION
Fixes #113 

MongoDB doesn't support `.` in parent field names.[[1](https://docs.mongodb.com/v3.4/reference/limits/#Restrictions-on-Field-Names)]
If an endpoint path contained `.` , mongoDB data was corrupted.
To fix this, `.` char will be replaced with it's unicode representation.
