### PR TITLE
improve uptime pump by adding more logs and removing the infinite loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -117,12 +117,15 @@ func initialisePumps() {
 	}
 
 	if !SystemConfig.DontPurgeUptimeData {
+		log.WithFields(logrus.Fields{
+			"prefix": mainPrefix,
+		}).Info("'dont_purge_uptime_data' set to false, attempting to start Uptime pump! ", UptimePump.GetName())
 		UptimePump = pumps.MongoPump{}
 		UptimePump.Init(SystemConfig.UptimePumpConfig)
 		log.WithFields(logrus.Fields{
 			"prefix": mainPrefix,
 		}).Info("Init Uptime Pump: ", UptimePump.GetName())
-	}
+	}	
 
 }
 

--- a/main.go
+++ b/main.go
@@ -125,7 +125,7 @@ func initialisePumps() {
 		log.WithFields(logrus.Fields{
 			"prefix": mainPrefix,
 		}).Info("Init Uptime Pump: ", UptimePump.GetName())
-	}	
+	}
 
 }
 

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -261,10 +261,12 @@ func (m *MongoPump) connect() {
 	dialInfo.Timeout = time.Second * 5
 	m.dbSession, err = mgo.DialWithInfo(dialInfo)
 
-	if err != nil {
+	for err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
-		}).Fatal("Mongo connection failed:", err)
+		}).Error("Mongo connection failed. Retrying. Err::", err)
+		time.Sleep(5 * time.Second)
+		m.dbSession, err = mgo.DialWithInfo(dialInfo)
 	}
 }
 

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -252,13 +252,13 @@ func (m *MongoPump) connect() {
 	var dialInfo *mgo.DialInfo
 
 	dialInfo, err = mongoDialInfo(m.dbConf.MongoURL, m.dbConf.MongoUseSSL, m.dbConf.MongoSSLInsecureSkipVerify)
-	dialInfo.Timeout = time.Second * 5;
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
 		}).Panic("Mongo URL is invalid: ", err)
 	}
 
+	dialInfo.Timeout = time.Second * 5
 	m.dbSession, err = mgo.DialWithInfo(dialInfo)
 
 	if err != nil {

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -252,6 +252,7 @@ func (m *MongoPump) connect() {
 	var dialInfo *mgo.DialInfo
 
 	dialInfo, err = mongoDialInfo(m.dbConf.MongoURL, m.dbConf.MongoUseSSL, m.dbConf.MongoSSLInsecureSkipVerify)
+	dialInfo.Timeout = time.Second * 5;
 	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
@@ -260,14 +261,10 @@ func (m *MongoPump) connect() {
 
 	m.dbSession, err = mgo.DialWithInfo(dialInfo)
 
-	// TODO - Should this not bail after a while?
-	for err != nil {
+	if err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
-		}).Error("Mongo connection failed:", err)
-
-		time.Sleep(5 * time.Second)
-		m.dbSession, err = mgo.DialWithInfo(dialInfo)
+		}).Fatal("Mongo connection failed:", err)
 	}
 }
 


### PR DESCRIPTION
currently the timeout is infinite, and there is no logs.  this is a poor user experience
this improves uptime pump by adding more logs and removing the infinite loop.

fixes https://github.com/TykTechnologies/tyk-pump/issues/117