### PR TITLE
Add support for AWS DocumentDB

### DIFF
--- a/pumps/mgo_helper_test.go
+++ b/pumps/mgo_helper_test.go
@@ -56,11 +56,14 @@ func (c *Conn) GetCollectionStats() (colStats bson.M) {
 }
 
 func defaultConf() MongoConf {
-	return MongoConf{
-		CollectionName:             colName,
-		MongoURL:                   dbAddr,
-		MongoSSLInsecureSkipVerify: true,
-		MaxInsertBatchSizeBytes:    10 * MiB,
-		MaxDocumentSizeBytes:       10 * MiB,
+	conf := MongoConf{
+		CollectionName:          colName,
+		MaxInsertBatchSizeBytes: 10 * MiB,
+		MaxDocumentSizeBytes:    10 * MiB,
 	}
+
+	conf.MongoURL = dbAddr
+	conf.MongoSSLInsecureSkipVerify = true
+
+	return conf
 }


### PR DESCRIPTION
Since AWS DocumentDB runs with TLS enabled, so it required a way to run it without disabling TLS verification.
DocumentDB use self-signed certs for verification, and provide a bundle with root certificates for verification, so we need a way to load this bundle.
Additionally DocumentDB can't be exposed to the local machine outside of VPC, which meant that even if verification is turned on, it will always fail since if we use ssh tunnel or similar, domain will differ from original.
Plus we may need a way to enable mutual TLS support.
Added the following options (on pump level):

- `mongo_ssl_ca_file` - path to the PEM file with trusted root certificates
- `mongo_ssl_pem_keyfile` - path to the PEM file which contains both client certificate and private key. Required for MutualTLS.
- `mongo_ssl_allow_invalid_hostnames` - ignore hostname check when it differ from origin (in cases with ssh tunneling). The rest of TLS verification still performed.

Additionally added detection if it is regular mongo or document DB, and in case of the last one, text search for APIs replaced by $regex fallback.

Working DocumentDB setup looks like this (assuming that there is SSH tunnel, proxying to 27018 port).

```
"mongo": {
    "type": "mongo",
    "meta": {
        "mongo_url": "mongodb://testest:testtest@127.0.0.1:27018/tyk_analytics",
        "mongo_use_ssl": true,
        "mongo_ssl_insecure_skip_verify": false,
        "mongo_ssl_ca_file": "~/rds-combined-ca-bundle.pem",
        "mongo_ssl_allow_invalid_hostnames": true,
    }
}
```

Additionally added check that if DocumentDB is found, it will disable background indexes (since it is not supported).
Long indexes now have explicit "names", so we can fit it into 64 char limit provided by DocumentDB.

Fix https://github.com/TykTechnologies/tyk-pump/issues/90
Fix https://github.com/TykTechnologies/tyk-pump/issues/89
Fix https://github.com/TykTechnologies/product/issues/191