### PR TITLE
Add dial info to Mongo connection error logs.

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -418,7 +418,7 @@ func (m *MongoPump) connect() {
 	for err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
-		}).Error("Mongo connection failed. Retrying. Err::", err)
+		}).WithError(err).WithField("dialinfo", dialInfo).Error("Mongo connection failed. Retrying.")
 		time.Sleep(5 * time.Second)
 		m.dbSession, err = mgo.DialWithInfo(dialInfo)
 	}

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -171,7 +171,7 @@ func (m *MongoAggregatePump) connect() {
 	for err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
-		}).Error("Mongo connection failed. Retrying. Err::", err)
+		}).WithError(err).WithField("dialinfo", dialInfo).Error("Mongo connection failed. Retrying.")
 		time.Sleep(5 * time.Second)
 		m.dbSession, err = mgo.DialWithInfo(dialInfo)
 	}

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -105,7 +105,7 @@ func (m *MongoSelectivePump) connect() {
 	for err != nil {
 		log.WithFields(logrus.Fields{
 			"prefix": mongoPrefix,
-		}).Error("Mongo connection failed. Retrying. Err::", err)
+		}).WithError(err).WithField("dialinfo", dialInfo).Error("Mongo connection failed. Retrying.")
 		time.Sleep(5 * time.Second)
 		m.dbSession, err = mgo.DialWithInfo(dialInfo)
 	}


### PR DESCRIPTION
Helps with feedback regarding issue #92.

- it is possible to specify settings for Mongo connections via
environment variables that are prefixed appropriately
- these log changes will show the dial info used by the Mongo connection
attempt so that any pertinent config changes can be seen, to aid
troubleshooting
- if the 'password' or other similarly sensitive fields on the dial info
struct were populated, they would show up in the error logs

For example, launching the pump with `PMP_MONGO_MONGOURL` set to `unavailable_url` would result in Mongo reporting the connection failure and (as a result of this change) including the bad URL in the error log, like so:
```
[Mar  4 10:09:57] ERROR mongo-pump: Mongo connection failed. Retrying. dialinfo=&{Addrs:[unavailable_url] ...
```
