### PR TITLE
fixed to "use_ssl" for Kafka per doc in tyk.io/doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,12 +215,10 @@ Create a `pump.conf` file:
         "broker": [
             "localhost:9092"
         ],
-        "ssl": {
-            "enabled": false,
-            "insecure_skip_verify": false
-        },
+	"topic": "tyk-pump",
+        "use_ssl": true,
+        "ssl_insecure_skip_verify": false
         "client_id": "tyk-pump",
-        "topic": "tyk-pump",
         "timeout": 60,
         "compressed": true,
         "meta_data": {


### PR DESCRIPTION
Per this doc https://tyk.io/docs/tyk-configuration-reference/tyk-pump-configuration/tyk-pump-configuration/#configuration
