### PR TITLE
Fix health endpoint to be published outside server.

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -32,7 +32,7 @@ func ServeHealthCheck(configHealthEndpoint string, configHealthPort int) {
 		"prefix": serverPrefix,
 	}).Info("Serving health check endpoint at http://localhost:", healthPort, "/", healthEndpoint)
 
-	http.ListenAndServe("localhost:"+fmt.Sprint(healthPort), router)
+	http.ListenAndServe(":"+fmt.Sprint(healthPort), router)
 }
 
 type Context struct{}


### PR DESCRIPTION
## Description
Fix healthCheck to be accessible from outside of the server. Currently is only accessible from localhost

## Related Issue
fixes #266

## Motivation and Context
Be able to check health of application from outside with monitoring tools.

## How This Has Been Tested
Locally test with
http://localhost:8080/health
http://10.160.255.103:8080/health
