### PR TITLE
Add new filters based on response_code's

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ This feature adds a new configuration field in each pump called filters and its 
   "skip_response_codes":[]
 }
 ```
-The fields api_ids, org_ids and response_codes works as whitelists (APIs and orgs where we want to send the analytics records) and the fields skip_api_ids, skip_org_ids and skip_response_codes works as the opposite (blackslits).
+The fields api_ids, org_ids and response_codes works as allow list (APIs and orgs where we want to send the analytics records) and the fields skip_api_ids, skip_org_ids and skip_response_codes works as block list.
 
 The priority is always blacklisted configurations over whitelisted.
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ This feature adds a new configuration field in each pump called filters and its 
 ```
 The fields api_ids, org_ids and response_codes works as allow list (APIs and orgs where we want to send the analytics records) and the fields skip_api_ids, skip_org_ids and skip_response_codes works as block list.
 
-The priority is always blacklisted configurations over whitelisted.
+The priority is always block list configurations over allow list.
 
 An example of configuration would be:
 ```json

--- a/README.md
+++ b/README.md
@@ -238,6 +238,37 @@ Create a `pump.conf` file:
 
 Settings are the same as for the original `tyk.conf` for redis and for mongoDB.
 
+### Filter Records
+
+This feature adds a new configuration field in each pump called filters and its structure is the following:
+```json
+"filters":{
+  "api_ids":[],
+  "org_ids":[],
+  "response_codes":[],
+  "skip_api_ids":[],
+  "skip_org_ids":[],
+  "skip_response_codes":[]
+}
+```
+The fields api_ids, org_ids and response_codes works as whitelists (APIs and orgs where we want to send the analytics records) and the fields skip_api_ids, skip_org_ids and skip_response_codes works as the opposite (blackslits).
+
+The priority is always blacklisted configurations over whitelisted.
+
+An example of configuration would be:
+```json
+"csv": {
+ "type": "csv",
+ "filters": {
+   "org_ids": ["org1","org2"]
+ },
+ "meta": {
+   "csv_dir": "./bar"
+ }
+}
+```
+
+
 ### Environment Variables
 
 Environment variables can be used to override the settings defined in the configuration file. See [Environment Variables](https://tyk.io/docs/tyk-configuration-reference/environment-variables/) in our docs for details. Where an environment variable is specified, its value will take precedence over the value in the configuration file.

--- a/analytics/analytics_filters.go
+++ b/analytics/analytics_filters.go
@@ -1,10 +1,12 @@
 package analytics
 
 type AnalyticsFilters struct {
-	OrgsIDs        []string `json:"org_ids"`
-	APIIDs         []string `json:"api_ids"`
-	SkippedOrgsIDs []string `json:"skip_org_ids"`
-	SkippedAPIIDs  []string `json:"skip_api_ids"`
+	OrgsIDs              []string `json:"org_ids"`
+	APIIDs               []string `json:"api_ids"`
+	ResponseCodes        []int    `json:"response_codes"`
+	SkippedOrgsIDs       []string `json:"skip_org_ids"`
+	SkippedAPIIDs        []string `json:"skip_api_ids"`
+	SkippedResponseCodes []int    `json:"skip_response_codes"`
 }
 
 func (filters AnalyticsFilters) ShouldFilter(record AnalyticsRecord) bool {
@@ -13,22 +15,35 @@ func (filters AnalyticsFilters) ShouldFilter(record AnalyticsRecord) bool {
 		return true
 	case len(filters.SkippedOrgsIDs) > 0 && stringInSlice(record.OrgID, filters.SkippedOrgsIDs):
 		return true
+	case len(filters.SkippedResponseCodes) > 0 && intInSlice(record.ResponseCode, filters.SkippedResponseCodes):
+		return true
 	case len(filters.APIIDs) > 0 && !stringInSlice(record.APIID, filters.APIIDs):
 		return true
 	case len(filters.OrgsIDs) > 0 && !stringInSlice(record.OrgID, filters.OrgsIDs):
+		return true
+	case len(filters.ResponseCodes) > 0 && !intInSlice(record.ResponseCode, filters.ResponseCodes):
 		return true
 	}
 	return false
 }
 
 func (filters AnalyticsFilters) HasFilter() bool {
-	if len(filters.SkippedAPIIDs) == 0 && len(filters.SkippedOrgsIDs) == 0 && len(filters.APIIDs) == 0 && len(filters.OrgsIDs) == 0 {
+	if len(filters.SkippedAPIIDs) == 0 && len(filters.SkippedOrgsIDs) == 0 && len(filters.ResponseCodes) == 0 && len(filters.APIIDs) == 0 && len(filters.OrgsIDs) == 0 && len(filters.SkippedResponseCodes) == 0 {
 		return false
 	}
 	return true
 }
 
 func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func intInSlice(a int, list []int) bool {
 	for _, b := range list {
 		if b == a {
 			return true

--- a/analytics/analytics_filters_test.go
+++ b/analytics/analytics_filters_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestShouldFilter(t *testing.T) {
 	record := AnalyticsRecord{
-		APIID: "apiid123",
-		OrgID: "orgid123",
+		APIID:        "apiid123",
+		OrgID:        "orgid123",
 		ResponseCode: 200,
 	}
 
@@ -89,7 +89,6 @@ func TestShouldFilter(t *testing.T) {
 	if shouldFilter == false {
 		t.Fatal("filter should be filtering the record")
 	}
-
 
 	//test no filter
 	filter = AnalyticsFilters{}

--- a/analytics/analytics_filters_test.go
+++ b/analytics/analytics_filters_test.go
@@ -6,6 +6,7 @@ func TestShouldFilter(t *testing.T) {
 	record := AnalyticsRecord{
 		APIID: "apiid123",
 		OrgID: "orgid123",
+		ResponseCode: 200,
 	}
 
 	//test skip_api_ids
@@ -20,6 +21,15 @@ func TestShouldFilter(t *testing.T) {
 	//test skip_org_ids
 	filter = AnalyticsFilters{
 		SkippedOrgsIDs: []string{"orgid123"},
+	}
+	shouldFilter = filter.ShouldFilter(record)
+	if shouldFilter == false {
+		t.Fatal("filter should be filtering the record")
+	}
+
+	//test skip_response_codes
+	filter = AnalyticsFilters{
+		SkippedResponseCodes: []int{200},
 	}
 	shouldFilter = filter.ShouldFilter(record)
 	if shouldFilter == false {
@@ -44,6 +54,15 @@ func TestShouldFilter(t *testing.T) {
 		t.Fatal("filter should not be filtering the record")
 	}
 
+	//test response_codes
+	filter = AnalyticsFilters{
+		ResponseCodes: []int{200},
+	}
+	shouldFilter = filter.ShouldFilter(record)
+	if shouldFilter == true {
+		t.Fatal("filter should not be filtering the record")
+	}
+
 	//test different org_ids
 	filter = AnalyticsFilters{
 		OrgsIDs: []string{"orgid321"},
@@ -61,6 +80,16 @@ func TestShouldFilter(t *testing.T) {
 	if shouldFilter == false {
 		t.Fatal("filter should be filtering the record")
 	}
+
+	//test different response_codes
+	filter = AnalyticsFilters{
+		ResponseCodes: []int{201},
+	}
+	shouldFilter = filter.ShouldFilter(record)
+	if shouldFilter == false {
+		t.Fatal("filter should be filtering the record")
+	}
+
 
 	//test no filter
 	filter = AnalyticsFilters{}


### PR DESCRIPTION
Add new filters based on response_code's

## Description
Currently we have the necessity to be able to only send with pump request with errors. For that we need to implement this new filter to be able to remove all 200 response code.


## Motivation and Context
Decrease space required to store all data of analytics . Request with 200 are not important to be monitorized and also are the 99% of traffic. We have some problems regarding sizing of our cluster of kafka and we want to reduce the load.

## How This Has Been Tested
-Unit test
-Start pump in local with same config of our staging environment with the new filter.
