### PR TITLE
Fix omit_detailed_recording on syslog pump

### DIFF
--- a/pumps/syslog.go
+++ b/pumps/syslog.go
@@ -16,6 +16,7 @@ type SyslogPump struct {
 	writer     *syslog.Writer
 	filters    analytics.AnalyticsFilters
 	timeout    int
+	CommonPumpConfig
 }
 
 var (


### PR DESCRIPTION
Ticket #269 introduced a change in the main pump data structure, this fix is required in order to prepare a build that incorporates both #269 and #189.