### PR TITLE
TT-556 blurred the sensitive data in mongo logs

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -79,7 +79,6 @@ type MongoConf struct {
 	CollectionCapEnable       bool   `json:"collection_cap_enable" mapstructure:"collection_cap_enable"`
 }
 
-
 func loadCertficateAndKeyFromFile(path string) (*tls.Certificate, error) {
 	raw, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -149,7 +149,7 @@ func (m *MongoAggregatePump) Init(config interface{}) error {
 
 	log.WithFields(logrus.Fields{
 		"prefix": analytics.MongoAggregatePrefix,
-	}).Debug("MongoDB DB CS: ", m.dbConf.MongoURL)
+	}).Debug("MongoDB DB CS: ", m.dbConf.GetBlurredURL())
 
 	return nil
 }

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -83,7 +83,7 @@ func (m *MongoSelectivePump) Init(config interface{}) error {
 
 	log.WithFields(logrus.Fields{
 		"prefix": mongoSelectivePrefix,
-	}).Debug("MongoDB DB CS: ", m.dbConf.MongoURL)
+	}).Debug("MongoDB DB CS: ", m.dbConf.GetBlurredURL())
 
 	return nil
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
The url set in the logs for the mongo Pump now contains the sensitive data blurred.

## Related Issue
https://tyktech.atlassian.net/browse/TT-556
https://github.com/TykTechnologies/tyk-pump/issues/282

## Motivation and Context
Give solution to https://tyktech.atlassian.net/browse/TT-556

## How This Has Been Tested
- Configure Pump file to use mongo
- Ran tyk-pump and check the logs
- The regex was also tested in https://regex101.com/r/E34wQO/1

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
