### PR TITLE
Update DogStatsD to support customizable tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+/.vscode
 .vagrant/
 build/
 build_tools/

--- a/README.md
+++ b/README.md
@@ -47,9 +47,7 @@ Create a `pump.conf` file:
   "pumps": {
     "dummy": {
       "type": "dummy",
-      "meta": {
-        
-      }
+      "meta": {}
     },
     "mongo": {
       "type": "mongo",
@@ -158,7 +156,18 @@ Create a `pump.conf` file:
         "async_uds": true,
         "async_uds_write_timeout_seconds": 2,
         "buffered": true,
-        "buffered_max_messages": 32
+        "buffered_max_messages": 32,
+        "tags": [
+          "method",
+          "response_code",
+          "api_version",
+          "api_name",
+          "api_id",
+          "org_id",
+          "tracked",
+          "path",
+          "oauth_id"
+        ]
       }
     },
     "prometheus": {
@@ -317,7 +326,7 @@ Environment variables can be used to override the settings defined in the config
 
 From v2.9.4, we have introduced a `/health` endpoint to confirm the Pump is running. You need to configure the following settings:
 
-- `health_check_endpoint_name` - The default is "hello" 
+- `health_check_endpoint_name` - The default is "hello"
 - `health_check_endpoint_port` - The default port is 8083
 
 This returns a HTTP 200 OK response if the Pump is running.
@@ -421,6 +430,20 @@ And the following Histogram for latencies:
 - `buffered`: Enable buffering of messages
 - `buffered_max_messages`: Max messages in single datagram if `buffered: true`. Default 16
 - `sample_rate`: default 1 which equates to 100% of requests. To sample at 50%, set to 0.5
+- `tags`: List of tags to be added to the metric. The possible options are listed in the below example
+
+If no tag is specified the fallback behavior is to use the below tags:
+- `path`
+- `method`
+- `response_code`
+- `api_version`
+- `api_name`
+- `api_id`
+- `org_id`
+- `tracked`
+- `oauth_id`
+
+Note that this configuration can generate significant charges due to the unbound nature of the `path` tag.
 
 ```.json
 "dogstatsd": {
@@ -432,7 +455,18 @@ And the following Histogram for latencies:
     "async_uds_write_timeout_seconds": 2,
     "buffered": true,
     "buffered_max_messages": 32,
-    "sample_rate": 0.5
+    "sample_rate": 0.5,
+    "tags": [
+      "method",
+      "response_code",
+      "api_version",
+      "api_name",
+      "api_id",
+      "org_id",
+      "tracked",
+      "path",
+      "oauth_id"
+    ]
   }
 },
 ```
@@ -500,11 +534,11 @@ More advanced fields:
 ### Kafka Config
 
 * `broker`: The list of brokers used to discover the partitions available on the kafka cluster. E.g. "localhost:9092"
-* `use_ssl`: Enables SSL connection. 
+* `use_ssl`: Enables SSL connection.
 * `ssl_insecure_skip_verify`: Controls whether the pump client verifies the kafka server's certificate chain and host name.
 * `client_id`: Unique identifier for client connections established with Kafka.
 * `topic`: The topic that the writer will produce messages to.
-* `timeout`: Timeout is the maximum amount of time will wait for a connect or write to complete. 
+* `timeout`: Timeout is the maximum amount of time will wait for a connect or write to complete.
 * `compressed`: Enable "github.com/golang/snappy" codec to be used to compress Kafka messages. By default is false
 * `meta_data`: Can be used to set custom metadata inside the kafka message
 * `ssl_cert_file`: Can be used to set custom certificate file for authentication with kafka.


### PR DESCRIPTION
There is no option to customize DogStatsD and this may have a negative impact on the billing with tags like `path` that are sent by default.

## Description
This PR adds an option to configure the tags pushed to DogStatsD.

## Motivation and Context
Decrease the cost of Datadog.

## How This Has Been Tested
There are no automated tests for the `dogstatsd.go` file. I did some manual tests and the code works.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [X] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [X] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [X] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Check your code additions will not fail linting checks:
  - [X] `go fmt -s`
  - [X] `go vet`