### PR TITLE
[TT-695] Mongo pumps Timeout

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,6 +133,9 @@ func initialisePumps() {
 			}).Error("Pump load error (skipping): ", err)
 		} else {
 			thisPmp := pmpType.New()
+			thisPmp.SetFilters(pmp.Filters)
+			thisPmp.SetTimeout(pmp.Timeout)
+			thisPmp.SetOmitDetailedRecording(pmp.OmitDetailedRecording)
 			initErr := thisPmp.Init(pmp.Meta)
 			if initErr != nil {
 				log.Error("Pump init error (skipping): ", initErr)
@@ -140,9 +143,6 @@ func initialisePumps() {
 				log.WithFields(logrus.Fields{
 					"prefix": mainPrefix,
 				}).Info("Init Pump: ", thisPmp.GetName())
-				thisPmp.SetFilters(pmp.Filters)
-				thisPmp.SetTimeout(pmp.Timeout)
-				thisPmp.SetOmitDetailedRecording(pmp.OmitDetailedRecording)
 				Pumps[i] = thisPmp
 			}
 		}

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -427,7 +427,9 @@ func (m *MongoPump) connect() {
 		}).Panic("Mongo URL is invalid: ", err)
 	}
 
-	dialInfo.Timeout = time.Second * 5
+	if m.timeout > 0 {
+		dialInfo.Timeout = time.Second * time.Duration(m.timeout)
+	}
 	m.dbSession, err = mgo.DialWithInfo(dialInfo)
 
 	for err != nil {

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -99,7 +99,10 @@ func (m *MongoSelectivePump) connect() {
 		}).Panic("Mongo URL is invalid: ", err)
 	}
 
-	dialInfo.Timeout = time.Second * 5
+	if m.timeout > 0 {
+		dialInfo.Timeout = time.Second * time.Duration(m.timeout)
+	}
+
 	m.dbSession, err = mgo.DialWithInfo(dialInfo)
 
 	for err != nil {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
The idea behind this PR is to make mongo pumps (mongo, mongo-aggregate, and mongo-selective) timeout configurable.
To do that, we modify the `dialInfo` in the connect method, since when we do a `mgo.DialWithInfo` to get the session, [the library sets](https://github.com/go-mgo/mgo/blob/a6b53ec6cb22a3699387a57a161566f9402ee85b/session.go#L426) the [SyncTimeout](https://godoc.org/gopkg.in/mgo.v2#Session.SetSyncTimeout) and [SocketTimeout](https://godoc.org/gopkg.in/mgo.v2#Session.SetSocketTimeout) and each time we try to write, we copy that session (the timeouts are re-initialized).

Also added a goroutine control in the mongo pump, since before it was spamming goroutines and don't do anything with the result (if it has an error or something).


## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-695


## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
https://tyktech.atlassian.net/browse/TT-695


## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

Scenario without timeout
- Start mongo docker and pump.
- Configure mongo pump or mongo-pump-aggregate without timeout.
- Run a script or ab to do a bunch of requests, for example, ab -n 100000 -c 1 http://tyk-gateway:8080/test/get 
- Stop mongo while the records are purging. 
- You should see that pump freeze waiting for the result.

Scenario with timeout
- Add a small timeout (1s for example).
Example conf:
```
        "mongo-pump-aggregate": {
            "name": "mongo-pump-aggregate",
            "meta": {
                "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics",
                "store_analytics_per_minute":true,
            },
            "use_mixed_collection": true,
            "track_all_paths" : false,
            "timeout":1
        }
```
- Run a script or ab to do a bunch of requests, for example ab -n 100000 -c 1 http://tyk-gateway:8080/test/get 
- Stop mongo while the records are purging.
- You should see that the pump timeout after the second and keeps fetching records from redis.
![image](https://user-images.githubusercontent.com/25751713/101854289-00111f80-3b40-11eb-9a54-dcbc8eac2038.png)
- Start mongo again and check if it auto reconnect.



## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
