### PR TITLE
 Add capability to obfuscate keys for all records

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Environment variables can be used to override the settings defined in the config
     "optimisation_max_active": 0,
     "enable_cluster": false,
     "redis_use_ssl": false,
-    "redis_ssl_insecure_skip_verify": false,
+    "redis_ssl_insecure_skip_verify": false
   },
 ```
 `redis_use_ssl` - Setting this to true to use SSL when connecting to Redis

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -148,17 +148,8 @@ func (a *AnalyticsRecord) ObfuscateKey() {
 	}
 
 	sDecodedRequest := string(decodeRequest)
-	log.WithFields(logrus.Fields{
-		"prefix":          analyticsRecordPrefix,
-		"apiId":           a.APIID,
-		"apiName:version": a.APIName + ":" + a.APIVersion,
-		"encoded request": a.RawRequest,
-		"decoded request": sDecodedRequest,
-	}).Debug("")
 
-	//todo bearer!
-
-	//Lookup the key and use it as the separator. Once the string is split, we obfuscate the key anf concatenate back
+	//Algorithm: Lookup the key and use it as the separator. Once the string is split, we obfuscate the key anf concatenate back
 	//the 2 parts with the obfuscated key in the middle
 	//
 	//Example:
@@ -174,14 +165,12 @@ func (a *AnalyticsRecord) ObfuscateKey() {
 			"encoded request": a.RawRequest,
 			"decoded request": sDecodedRequest,
 		}).Error("Authorization key hasn't been found in the decoded string")
-		log.Debug("Authorization key hasn't been found, split array length:", len(requestWithoutKey))
 
 		return
 	}
 	reqWithObfuscatedKey := requestWithoutKey[0] + a.APIKey + requestWithoutKey[1]
 
 	a.RawRequest = base64.StdEncoding.EncodeToString([]byte(reqWithObfuscatedKey))
-	log.Debug("Encoded RawRequest:", a.RawRequest)
 }
 
 func ObfuscateString(keyName string) string {

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -2,7 +2,6 @@ package analytics
 
 import (
 	"encoding/base64"
-	"fmt"
 	"reflect"
 	"strconv"
 	"strings"
@@ -155,7 +154,6 @@ func (a *AnalyticsRecord) ObfuscateKey() {
 	//Example:
 	// GET ...Authorization: 59d27324b8125f000137663e2c650c3576b348bfbe1490fef5db0c49 ...\r\n
 	// GET ...Authorization: ****0c49 ...\r\n
-	fmt.Println(" before a.APIKey  " + a.APIKey)
 	requestWithoutKey := strings.Split(sDecodedRequest, fullApiKey)
 	if len(requestWithoutKey) != 2 {
 		log.WithFields(logrus.Fields{

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -25,21 +25,16 @@ func TestObfuscateKeys(t *testing.T) {
 			Authorization: \r\n
 			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
-			AnalyticsRecord{
-				APIKey: "",
-				//RawRequest: "R0VUIGlwIEhUVFAvMS4xCkhvc3Q6IGxvY2FsaG9zdDo4MDgwClVzZXItQWdlbnQ6IFBvc3RtYW5SdW50aW1lLzcuMjYuMQpBY2NlcHQ6ICovKgpBY2NlcHQtRW5jb2Rpbmc6IGd6aXAsIGRlZmxhdGUsIGJyCkF1dGhvcml6YXRpb246ClBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NQpYLUFwaS1WZXJzaW9uOiB2MgoK"
-				// Decoded raw request:
-			},
+			AnalyticsRecord{APIKey: ""},
 			"",
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogXHJcbgoJCQlQb3N0bWFuLVRva2VuOiA5MzRlMDhiYS1iZDZiLTQ2MGYtYmVlMy1jMTM3NTZiNGY0NDVcblgtQXBpLVZlcnNpb246IHYyXHJcbgoJCQlcclxuXHJcbg==",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//Authorization: \r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			Authorization: \r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			\r\n\r\n`, //RawRequest: "R0VUIGlwIEhUVFAvMS4xCkhvc3Q6IGxvY2FsaG9zdDo4MDgwClVzZXItQWdlbnQ6IFBvc3RtYW5SdW50aW1lLzcuMjYuMQpBY2NlcHQ6ICovKgpBY2NlcHQtRW5jb2Rpbmc6IGd6aXAsIGRlZmxhdGUsIGJyCkF1dGhvcml6YXRpb246ClBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NQpYLUFwaS1WZXJzaW9uOiB2MgoK"
 		},
 		{
 			"Record_with_regular_key",
@@ -53,15 +48,14 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "59d27324b8125f000137663e2c650c3576b348bfbe1490fef5db0c49"},
 			"****0c49", // Been obfuscated
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjBjNDlcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//Authorization: ****0c49\r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			Authorization: ****0c49\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			\r\n\r\n`, //"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjBjNDlcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
 		},
 		{
 			"Record_with_key_length_less_than4",
@@ -75,15 +69,14 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "a59d"},
 			"----", // Been obfuscated
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogLS0tLVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//Authorization: ----\r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			Authorization: ----\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			\r\n\r\n`, // "R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogLS0tLVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
 		},
 		{
 			"Record_with_new_format_key",
@@ -97,15 +90,14 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6InlhYXJhMTIzIiwiaCI6Im11cm11cjY0In0="},
 			"****In0=", // Been obfuscated
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKkluMD1cclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjIKCQkJXHJcblxyXG4=",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//Authorization: ****In0=\r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			Authorization: ****In0=\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			\r\n\r\n`, // "R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKkluMD1cclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjIKCQkJXHJcblxyXG4=",
 		},
 		{
 			"Record_with_key_length_of_5",
@@ -119,15 +111,15 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "12345"},
 			"****2345", // Been obfuscated
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjIzNDVcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//Authorization: ****2345\r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			Authorization: ****2345\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			\r\n\r\n`, // "R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjIzNDVcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
+
 		},
 		{
 			"Authorization_custom_header", // Authorisation with 's'
@@ -141,15 +133,14 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6InlhYXJhMTIzIiwiaCI6Im11cm11cjY0In0="},
 			"****In0=", // Been obfuscated,
-			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJWC1BdXRob3Jpc2F0aW9uOiAqKioqSW4wPVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
-			//`GET ip HTTP/1.1\r\n
-			//Host: localhost:8080\r\n
-			//User-Agent: PostmanRuntime/7.26.1\r\n
-			//Accept: */*\r\n
-			//Accept-Encoding: gzip, deflate, br\r\n
-			//X-Authorisation: ****In0=\r\n
-			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
-			//\r\n\r\n`,
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
+			User-Agent: PostmanRuntime/7.26.1\r\n
+			Accept: */*\r\n
+			Accept-Encoding: gzip, deflate, br\r\n
+			X-Authorisation: ****In0=\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			\r\n\r\n`, //"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJWC1BdXRob3Jpc2F0aW9uOiAqKioqSW4wPVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
 		},
 	}
 
@@ -162,6 +153,7 @@ func TestObfuscateKeys(t *testing.T) {
 				t.Errorf("Error in obfuscated key: expected %s, actual %s",
 					tc.expectedKey, tc.record.APIKey)
 			}
+			tc.expectedRequest = base64.StdEncoding.EncodeToString([]byte(tc.expectedRequest))
 			if tc.record.RawRequest != tc.expectedRequest {
 				t.Errorf("Error in obfuscated raw request: \nexpected request %s,\n actual raw request %s",
 					tc.expectedRequest, tc.record.RawRequest)

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -7,28 +7,25 @@ import (
 
 func TestObfuscateKeys(t *testing.T) {
 
-	const (
-		DECODE_REQUEST = true
-		AUTH_HEADER_NAME = "Authorization"
-	)
+	const AUTH_HEADER_NAME = "Authorization"
 
 	cases := []struct {
 		testName          string
 		decodedRawRequest string
 		record            AnalyticsRecord
 		authHeaderName    string
-		decodeRawRequest	bool
 		expectedKey       string
 		expectedRequest   string
 	}{
 		{
-			"Record with an empty key",
+			"Record_with_an_empty_key",
 			//"GET ip HTTP/1.1\nHost: localhost:8080\nUser-Agent: PostmanRuntime/7.26.1\nAccept: */*\nAccept-Encoding: gzip, deflate, br\nAuthorization:\nPostman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\n"
-			`GET ip HTTP/1.1\r\nHost: localhost:8080\r\n
+			`GET ip HTTP/1.1\r\n
+			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
 			Accept: */*\r\n
 			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: ss\r\n
+			Authorization: \r\n
 			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
 			AnalyticsRecord{
@@ -37,65 +34,65 @@ func TestObfuscateKeys(t *testing.T) {
 				// Decoded raw request:
 			},
 			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
-			"----",
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: \r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			"",
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogXHJcbgoJCQlQb3N0bWFuLVRva2VuOiA5MzRlMDhiYS1iZDZiLTQ2MGYtYmVlMy1jMTM3NTZiNGY0NDVcblgtQXBpLVZlcnNpb246IHYyXHJcbgoJCQlcclxuXHJcbg==",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//Authorization: \r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			//\r\n\r\n`,
 		},
 		{
-			"Record with regular key",
+			"Record_with_regular_key",
 			`GET ip HTTP/1.1\r\n
 			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
 			Accept: */*\r\n
 			Accept-Encoding: gzip, deflate, br\r\n
 			Authorization: 59d27324b8125f000137663e2c650c3576b348bfbe1490fef5db0c49\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "59d27324b8125f000137663e2c650c3576b348bfbe1490fef5db0c49"},
 			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
 			"****0c49", // Been obfuscated
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: ****0c49\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjBjNDlcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//Authorization: ****0c49\r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			//\r\n\r\n`,
 		},
 		{
-			"Record with key length <= 4",
+			"Record_with_key_length_less_than4",
 			`GET ip HTTP/1.1\r\n
 			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
 			Accept: */*\r\n
 			Accept-Encoding: gzip, deflate, br\r\n
 			Authorization: a59d\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "a59d"},
 			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
 			"----", // Been obfuscated
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: ----\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogLS0tLVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//Authorization: ----\r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			//\r\n\r\n`,
 		},
 		{
-			"Record with new format key",
+			"Record_with_new_format_key",
 			`GET ip HTTP/1.1\r\n
 			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
@@ -106,62 +103,62 @@ func TestObfuscateKeys(t *testing.T) {
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6InlhYXJhMTIzIiwiaCI6Im11cm11cjY0In0="},
 			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
 			"****In0=", // Been obfuscated
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: ****In0=\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKkluMD1cclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjIKCQkJXHJcblxyXG4=",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//Authorization: ****In0=\r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			//\r\n\r\n`,
 		},
 		{
-			"Record with key length of 5",
+			"Record_with_key_length_of_5",
 			`GET ip HTTP/1.1\r\n
 			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
 			Accept: */*\r\n
 			Accept-Encoding: gzip, deflate, br\r\n
 			Authorization: 12345\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
 			AnalyticsRecord{APIKey: "12345"},
 			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
 			"****2345", // Been obfuscated
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorization: ****2345\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJQXV0aG9yaXphdGlvbjogKioqKjIzNDVcclxuCgkJCVBvc3RtYW4tVG9rZW46IDkzNGUwOGJhLWJkNmItNDYwZi1iZWUzLWMxMzc1NmI0ZjQ0NVxuWC1BcGktVmVyc2lvbjogdjJcclxuCgkJCVxyXG5cclxu",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//Authorization: ****2345\r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			//\r\n\r\n`,
 		},
 		{
-			"Authorization header not found", // Authorisation with 's'
+			"Authorization_custom_header", // Authorisation with 's'
 			`GET ip HTTP/1.1\r\n
 			Host: localhost:8080\r\n
 			User-Agent: PostmanRuntime/7.26.1\r\n
 			Accept: */*\r\n
 			Accept-Encoding: gzip, deflate, br\r\n
-			Authorisation: 12345\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
+			X-Authorisation: eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6InlhYXJhMTIzIiwiaCI6Im11cm11cjY0In0=\r\n
+			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
 			\r\n\r\n`,
-			AnalyticsRecord{APIKey: "12345"},
-			AUTH_HEADER_NAME,
-			DECODE_REQUEST,
-			"****2345", // Been obfuscated
-			`GET ip HTTP/1.1\r\n
-			Host: localhost:8080\r\n
-			User-Agent: PostmanRuntime/7.26.1\r\n
-			Accept: */*\r\n
-			Accept-Encoding: gzip, deflate, br\r\n
-			Authorisation: 12345\r\n
-			Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2
-			\r\n\r\n`,
+			AnalyticsRecord{APIKey: "eyJvcmciOiI1ZTlkOTU0NGExZGNkNjAwMDFkMGVkMjAiLCJpZCI6InlhYXJhMTIzIiwiaCI6Im11cm11cjY0In0="},
+			"X-Authorisation",
+			"****In0=", // Been obfuscated,
+			"R0VUIGlwIEhUVFAvMS4xXHJcbgoJCQlIb3N0OiBsb2NhbGhvc3Q6ODA4MFxyXG4KCQkJVXNlci1BZ2VudDogUG9zdG1hblJ1bnRpbWUvNy4yNi4xXHJcbgoJCQlBY2NlcHQ6ICovKlxyXG4KCQkJQWNjZXB0LUVuY29kaW5nOiBnemlwLCBkZWZsYXRlLCBiclxyXG4KCQkJWC1BdXRob3Jpc2F0aW9uOiAqKioqSW4wPVxyXG4KCQkJUG9zdG1hbi1Ub2tlbjogOTM0ZTA4YmEtYmQ2Yi00NjBmLWJlZTMtYzEzNzU2YjRmNDQ1XG5YLUFwaS1WZXJzaW9uOiB2MlxyXG4KCQkJXHJcblxyXG4=",
+			//`GET ip HTTP/1.1\r\n
+			//Host: localhost:8080\r\n
+			//User-Agent: PostmanRuntime/7.26.1\r\n
+			//Accept: */*\r\n
+			//Accept-Encoding: gzip, deflate, br\r\n
+			//X-Authorisation: ****In0=\r\n
+			//Postman-Token: 934e08ba-bd6b-460f-bee3-c13756b4f445\nX-Api-Version: v2\r\n
+			//\r\n\r\n`,
 		},
 	}
 
@@ -169,13 +166,13 @@ func TestObfuscateKeys(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			//Calculating the raw request
 			tc.record.RawRequest = base64.StdEncoding.EncodeToString([]byte(tc.decodedRawRequest))
-			tc.record.ObfuscateKey(tc.authHeaderName, tc.decodeRawRequest)
+			tc.record.ObfuscateKey(tc.authHeaderName)
 			if tc.record.APIKey != tc.expectedKey {
 				t.Errorf("Error in obfuscated key: expected %s, actual %s",
 					tc.expectedKey, tc.record.APIKey)
 			}
 			if tc.record.RawRequest != tc.expectedRequest {
-				t.Errorf("Error in obfuscated raw request: \nexpected %s,\n actual %s",
+				t.Errorf("Error in obfuscated raw request: \nexpected request %s,\n actual raw request %s",
 					tc.expectedRequest, tc.record.RawRequest)
 			}
 		})

--- a/config.go
+++ b/config.go
@@ -41,8 +41,7 @@ type TykPumpConfiguration struct {
 	HealthCheckEndpointName string                     `json:"health_check_endpoint_name"`
 	HealthCheckEndpointPort int                        `json:"health_check_endpoint_port"`
 	OmitDetailedRecording   bool                       `json:"omit_detailed_recording"`
-	base64DecodeRawData			bool											 `json:"base64_decode_raw_data"`
-	obfuscateAuthHeader		  ObfuscateAuthHeader
+	obfuscateAuthHeader     ObfuscateAuthHeader        `json:"obfuscate_auth_header"`
 }
 
 func LoadConfig(filePath *string, configStruct *TykPumpConfiguration) {

--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func filterData(pump pumps.Pump, keys []interface{}) []interface{} {
 			continue
 		}
 		if SystemConfig.obfuscateAuthHeader.ObfuscateKeys {
-			decoded.ObfuscateKey(SystemConfig.obfuscateAuthHeader.AuthHeaderName, SystemConfig.base64DecodeRawData)
+			decoded.ObfuscateKey(SystemConfig.obfuscateAuthHeader.AuthHeaderName)
 		}
 		filteredKeys[newLenght] = decoded
 		newLenght++

--- a/main_test.go
+++ b/main_test.go
@@ -74,7 +74,7 @@ func TestDontObfuscateKeysAndFilterData(t *testing.T) {
 	SystemConfig = TykPumpConfiguration{}
 
 	//Since it's false no need to set it, added just to explain
-	//ObfuscateKeys = false //Log keys, dont obfuscate them
+	//ObfuscateKeys = false //Log the actual keys, dont obfuscate them
 
 	mockedPump := &MockedPump{}
 
@@ -91,11 +91,11 @@ func TestDontObfuscateKeysAndFilterData(t *testing.T) {
 	expectedKeys[3] = ""            // empty key
 
 	keys := make([]interface{}, 5)
-	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "1234"}
-	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: "12345678910"}
-	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "my-secret"}
-	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: ""}
-	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"} //should be filtered out
+	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: expectedKeys[0]}
+	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: expectedKeys[1]}
+	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: expectedKeys[2]}
+	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: expectedKeys[3]}
+	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "blabla"} //should be filtered out anyway
 
 	filteredKeys := filterData(mockedPump, keys)
 	if len(keys) == len(filteredKeys) {
@@ -118,7 +118,7 @@ func TestDontObfuscateKeysAndDontFilterData(t *testing.T) {
 	SystemConfig = TykPumpConfiguration{}
 
 	//Since it's false no need to set it, added just to explain
-	//SystemConfig.ObfuscateKeys = false //Log keys, dont obfuscate them
+	//SystemConfig.ObfuscateKeys = false //Log the actual keys, dont obfuscate them
 
 	mockedPump := &MockedPump{}
 
@@ -130,11 +130,11 @@ func TestDontObfuscateKeysAndDontFilterData(t *testing.T) {
 	expectedKeys[4] = "1234"        // 1234 key
 
 	keys := make([]interface{}, 5)
-	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "1234"}
-	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: "12345678910"}
-	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "my-secret"}
-	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: ""}
-	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"} //should be filtered out
+	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: expectedKeys[0]}
+	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: expectedKeys[1]}
+	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: expectedKeys[2]}
+	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: expectedKeys[3]}
+	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: expectedKeys[4]}
 
 	filteredKeys := filterData(mockedPump, keys)
 	expectedLen := len(keys)
@@ -213,7 +213,7 @@ func TestObfuscateKeysAndFilterData(t *testing.T) {
 	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "my-secret"}
 	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: ""}
 	keys[4] = analytics.AnalyticsRecord{APIID: "api321", APIKey: "12345"}
-	keys[5] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"}
+	keys[5] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "blabla"}
 
 	filteredKeys := filterData(mockedPump, keys)
 	if len(keys) == len(filteredKeys) {

--- a/main_test.go
+++ b/main_test.go
@@ -156,23 +156,21 @@ func TestDontObfuscateKeysAndDontFilterData(t *testing.T) {
 
 func TestObfuscateKeysAndDontFilterData(t *testing.T) {
 	SystemConfig = TykPumpConfiguration{}
-	SystemConfig.obfuscateAuthHeader = ObfuscateAuthHeader{ true, "Authorization" }
+	SystemConfig.obfuscateAuthHeader = ObfuscateAuthHeader{true, "Authorization"}
 
 	mockedPump := &MockedPump{}
 
-	expectedKeys := make([]string, 5)
+	expectedKeys := make([]string, 4)
 	expectedKeys[0] = "----"     // len(key) <= 4
 	expectedKeys[1] = "****8910" // key = 12345678910
 	expectedKeys[2] = "****cret" // key = my-secret
-	expectedKeys[3] = "----"     // empty key
-	expectedKeys[4] = "----"     // empty key
+	expectedKeys[3] = ""         // empty key
 
-	keys := make([]interface{}, 5)
+	keys := make([]interface{}, 4)
 	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "1234"}
 	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: "12345678910"}
 	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "my-secret"}
 	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: ""}
-	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"}
 
 	filteredKeys := filterData(mockedPump, keys)
 	if len(keys) != len(filteredKeys) {
@@ -192,7 +190,7 @@ func TestObfuscateKeysAndDontFilterData(t *testing.T) {
 
 func TestObfuscateKeysAndFilterData(t *testing.T) {
 	SystemConfig = TykPumpConfiguration{}
-	SystemConfig.obfuscateAuthHeader = ObfuscateAuthHeader{ true, "Authorization" }
+	SystemConfig.obfuscateAuthHeader = ObfuscateAuthHeader{true, "Authorization"}
 
 	mockedPump := &MockedPump{}
 
@@ -202,18 +200,20 @@ func TestObfuscateKeysAndFilterData(t *testing.T) {
 		},
 	)
 
-	expectedKeys := make([]string, 4)
+	expectedKeys := make([]string, 5)
 	expectedKeys[0] = "----"     // len(key) <= 4
 	expectedKeys[1] = "****8910" // key = 12345678910
 	expectedKeys[2] = "****cret" // key = my-secret
-	expectedKeys[3] = "----"     // empty key
+	expectedKeys[3] = ""         // empty key
+	expectedKeys[4] = "****2345" // 5 chars key
 
-	keys := make([]interface{}, 5)
+	keys := make([]interface{}, 6)
 	keys[0] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "1234"}
 	keys[1] = analytics.AnalyticsRecord{APIID: "api456", APIKey: "12345678910"}
 	keys[2] = analytics.AnalyticsRecord{APIID: "api123", APIKey: "my-secret"}
 	keys[3] = analytics.AnalyticsRecord{APIID: "api321", APIKey: ""}
-	keys[4] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"}
+	keys[4] = analytics.AnalyticsRecord{APIID: "api321", APIKey: "12345"}
+	keys[5] = analytics.AnalyticsRecord{APIID: "api789", APIKey: "1234"}
 
 	filteredKeys := filterData(mockedPump, keys)
 	if len(keys) == len(filteredKeys) {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

While filtering the record I thought it's good timing to obfuscate the key. For every record, I check if it needs to be filtered out and then obfuscate the key.
There's a global config field to turn this on - obfuscate_keys
Added TestObfuscateKeys just for that obfuscation function.
Added tests for filter+obfuscation of keys in a record

~Important: This PR is only useful if keys are not hashed, otherwise there's no real reason to obfuscate the key but it works for both cases.~
About hashed keys (that is set in the GW):
- In the case of detailed recording, it doesn't matter since we record the request as-is, and as such, you can see the authorization header in the raw request.
- If there is no detailed recording set, then APIKey field in the analytic record has the key so customers that don't hash keys might want to obfuscate this field to avoid leak when data go outside the tyk management platform.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
When recording the full request body, the authorization header gets recorded as well. From obvious reasons, sometimes this is problematic for clients. For example, you don't want the people that check the analytics to have access to user's keys.
Important to note that it's not enough, that it'll be better to add such fix in the source, i.e. the gateway itself should remove this header before saving the analytic record.


## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
- Wrote unit tests to test `ObfuscateKey` function
- Wrote tests to test `filterData` that call `ObfuscateKey` - tests with data to filter and without.

How to test:
1. Hashed keys - `"hash_keys": true`:
    1.1. "detailed_recording" on - you can set it in the key. 
         `"obfuscate_key": true` in pump.conf and make API call.
         **Result**: the analytic record of the call should have "****wxyz" instead of the **actual** key in the raw request field and APIKey field should look similar (similar since it's a **hashed** key).
   1.2. "detailed_recording" off - 
         `"obfuscate_key": true` in pump.conf and make API call.
         **Result**: the analytic record of the call should have "****abcd" instead of the **hashed** key in the APIKey field.
2. Cleartext keys -`"hash_keys": false`:
 2.1. "detailed_recording" on - you can set it in the key. 
         `"obfuscate_key": true` in pump.conf and make API call.
         **Result**: the analytic record of the call should have "****wxyz" instead of the **actual** key in the raw request field and "****wxyz" in the APIKey field.
   2.2. "detailed_recording" off - 
         `"obfuscate_key": true` in pump.conf and make API call.
         **Result**: the analytic record of the call should have "****wxyz" instead of the **actual** key in the APIKey field.
3. Test the above with filter data, for instance, set to filter api1 and call api1 and api2 and verify it still works as expected.
```
"filters":{
  "api_ids":[<API-ID>],
```


## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
