### PR TITLE
[TT-1574] Multiple analytics keys

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,22 +22,21 @@ type PumpConfig struct {
 }
 
 type TykPumpConfiguration struct {
-	PurgeDelay                  int                        `json:"purge_delay"`
-	PurgeChunk                  int64                      `json:"purge_chunk"`
-	StorageExpirationTime       int64                      `json:"storage_expiration_time"`
-	DontPurgeUptimeData         bool                       `json:"dont_purge_uptime_data"`
-	UptimePumpConfig            map[string]interface{}     `json:"uptime_pump_config"`
-	Pumps                       map[string]PumpConfig      `json:"pumps"`
-	AnalyticsStorageType        string                     `json:"analytics_storage_type"`
-	EnableMultipleAnalyticsKeys bool                       `json:"enable_multiple_analytics_keys"`
-	AnalyticsStorageConfig      storage.RedisStorageConfig `json:"analytics_storage_config"`
-	StatsdConnectionString      string                     `json:"statsd_connection_string"`
-	StatsdPrefix                string                     `json:"statsd_prefix"`
-	LogLevel                    string                     `json:"log_level"`
-	HealthCheckEndpointName     string                     `json:"health_check_endpoint_name"`
-	HealthCheckEndpointPort     int                        `json:"health_check_endpoint_port"`
-	OmitDetailedRecording       bool                       `json:"omit_detailed_recording"`
-	ObfuscateKeys               bool                       `json:"obfuscate_keys"`
+	PurgeDelay              int                        `json:"purge_delay"`
+	PurgeChunk              int64                      `json:"purge_chunk"`
+	StorageExpirationTime   int64                      `json:"storage_expiration_time"`
+	DontPurgeUptimeData     bool                       `json:"dont_purge_uptime_data"`
+	UptimePumpConfig        map[string]interface{}     `json:"uptime_pump_config"`
+	Pumps                   map[string]PumpConfig      `json:"pumps"`
+	AnalyticsStorageType    string                     `json:"analytics_storage_type"`
+	AnalyticsStorageConfig  storage.RedisStorageConfig `json:"analytics_storage_config"`
+	StatsdConnectionString  string                     `json:"statsd_connection_string"`
+	StatsdPrefix            string                     `json:"statsd_prefix"`
+	LogLevel                string                     `json:"log_level"`
+	HealthCheckEndpointName string                     `json:"health_check_endpoint_name"`
+	HealthCheckEndpointPort int                        `json:"health_check_endpoint_port"`
+	OmitDetailedRecording   bool                       `json:"omit_detailed_recording"`
+	ObfuscateKeys           bool                       `json:"obfuscate_keys"`
 }
 
 func LoadConfig(filePath *string, configStruct *TykPumpConfiguration) {

--- a/config.go
+++ b/config.go
@@ -22,21 +22,22 @@ type PumpConfig struct {
 }
 
 type TykPumpConfiguration struct {
-	PurgeDelay              int                        `json:"purge_delay"`
-	PurgeChunk              int64                      `json:"purge_chunk"`
-	StorageExpirationTime   int64                      `json:"storage_expiration_time"`
-	DontPurgeUptimeData     bool                       `json:"dont_purge_uptime_data"`
-	UptimePumpConfig        map[string]interface{}     `json:"uptime_pump_config"`
-	Pumps                   map[string]PumpConfig      `json:"pumps"`
-	AnalyticsStorageType    string                     `json:"analytics_storage_type"`
-	AnalyticsStorageConfig  storage.RedisStorageConfig `json:"analytics_storage_config"`
-	StatsdConnectionString  string                     `json:"statsd_connection_string"`
-	StatsdPrefix            string                     `json:"statsd_prefix"`
-	LogLevel                string                     `json:"log_level"`
-	HealthCheckEndpointName string                     `json:"health_check_endpoint_name"`
-	HealthCheckEndpointPort int                        `json:"health_check_endpoint_port"`
-	OmitDetailedRecording   bool                       `json:"omit_detailed_recording"`
-	ObfuscateKeys           bool                       `json:"obfuscate_keys"`
+	PurgeDelay                  int                        `json:"purge_delay"`
+	PurgeChunk                  int64                      `json:"purge_chunk"`
+	StorageExpirationTime       int64                      `json:"storage_expiration_time"`
+	DontPurgeUptimeData         bool                       `json:"dont_purge_uptime_data"`
+	UptimePumpConfig            map[string]interface{}     `json:"uptime_pump_config"`
+	Pumps                       map[string]PumpConfig      `json:"pumps"`
+	AnalyticsStorageType        string                     `json:"analytics_storage_type"`
+	EnableMultipleAnalyticsKeys bool                       `json:"enable_multiple_analytics_keys"`
+	AnalyticsStorageConfig      storage.RedisStorageConfig `json:"analytics_storage_config"`
+	StatsdConnectionString      string                     `json:"statsd_connection_string"`
+	StatsdPrefix                string                     `json:"statsd_prefix"`
+	LogLevel                    string                     `json:"log_level"`
+	HealthCheckEndpointName     string                     `json:"health_check_endpoint_name"`
+	HealthCheckEndpointPort     int                        `json:"health_check_endpoint_port"`
+	OmitDetailedRecording       bool                       `json:"omit_detailed_recording"`
+	ObfuscateKeys               bool                       `json:"obfuscate_keys"`
 }
 
 func LoadConfig(filePath *string, configStruct *TykPumpConfiguration) {

--- a/main.go
+++ b/main.go
@@ -171,7 +171,7 @@ func StartPurgeLoop(secInterval int, chunkSize int64, expire time.Duration, omit
 				//if it's the first iteration, we look for tyk-system-analytics to maintain backwards compatibility or if analytics_config.enable_multiple_analytics_keys is disabled in the gateway
 				analyticsKeyName = storage.ANALYTICS_KEYNAME
 			} else {
-				analyticsKeyName = storage.ANALYTICS_KEYNAME + "_" + fmt.Sprint(i)
+				analyticsKeyName = fmt.Sprintf("%v_%v", storage.ANALYTICS_KEYNAME, i)
 			}
 			AnalyticsValues := AnalyticsStore.GetAndDeleteSet(analyticsKeyName, chunkSize, expire)
 			if len(AnalyticsValues) > 0 {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
This PR adds support for multiple analytic keys and is backward compatible with the old analytic key (`tyk-system-analytic`).

It just basically do the following process:
Iterate from -1 to 9:
- If the iteration is -1 (the first one), we're going to look for the old analytic key (`tyk-system-analytic`)
- If the iteration is from 0 to 9, we're going to look for the new divided key (`tyk-system-analytic_X` where X is the iteration number)
- Read from the Redis the key 
- Process data
- Jump to the next key

This allows us to:
- Loss fewer analytics records if a pump fails since it will only lose the records from one of the keys.
- If the Redis cluster is enabled, read the analytics across multiple nodes. 


## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-1574
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Reduce redis overload and have a better analytics distribution across the cluster. Also to have better fault tolerance in the pump.

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
- Set enable_multiple_analytics_keys:true in the pump and analytics_config.enable_multiple_analytics_keys:true in the gateway.
- Using redis cluster (https://github.com/Grokzen/docker-redis-cluster) or/and standalone Redis.
- Setup any pump (CSV and dummy in my tests).
- Send 100 requests to a gw API.
- Your pumps should process 100 analytics records.

If you keep sending requests and turn off the pump, you should see in Redis multiple analytics keys with the following format: tyk-system-analytics_X where X goes from 0 to 9. And each key should have different records inside.


## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
