### PR TITLE
[TT-2783] Implement table sharding for SQLAggregatePump

### DIFF
--- a/pumps/sql_aggregate.go
+++ b/pumps/sql_aggregate.go
@@ -94,6 +94,11 @@ func (c *SQLAggregatePump) Init(conf interface{}) error {
 	return nil
 }
 
+// WriteData aggregates and writes the passed data to SQL database. When table sharding is enabled, startIndex and endIndex
+// are found by checking timestamp of the records. The main for loop iterates and finds the index where a new day starts.
+// Then, the data is passed to AggregateData function and written to database day by day on different tables. However,
+// if table sharding is not enabled, the for loop iterates one time and all data is passed at once to the AggregateData
+// function and written to database on single table.
 func (c *SQLAggregatePump) WriteData(ctx context.Context, data []interface{}) error {
 	dataLen := len(data)
 	c.log.Debug("Attempting to write ", dataLen, " records...")

--- a/pumps/sql_aggregate_test.go
+++ b/pumps/sql_aggregate_test.go
@@ -41,17 +41,12 @@ func TestSQLAggregateWriteData_Sharded(t *testing.T) {
 	pmp := SQLAggregatePump{}
 	cfg := make(map[string]interface{})
 	cfg["type"] = "sqlite"
-	cfg["connection_string"] = "pmp_test.db"
 	cfg["table_sharding"] = true
 
 	err := pmp.Init(cfg)
 	if err != nil {
 		t.Fatal("SQL Pump Aggregate couldn't be initialized with err: ", err)
 	}
-
-	defer func() {
-		os.Remove("pmp_test.db")
-	}()
 
 	keys := make([]interface{}, 7)
 	now := time.Now()
@@ -94,16 +89,11 @@ func TestSQLAggregateWriteData(t *testing.T) {
 	pmp := SQLAggregatePump{}
 	cfg := make(map[string]interface{})
 	cfg["type"] = "sqlite"
-	cfg["connection_string"] = "pmp_test.db"
 
 	err := pmp.Init(cfg)
 	if err != nil {
 		t.Fatal("SQL Pump Aggregate couldn't be initialized with err: ", err)
 	}
-
-	defer func() {
-		os.Remove("pmp_test.db")
-	}()
 
 	keys := make([]interface{}, 3)
 	keys[0] = analytics.AnalyticsRecord{APIID: "api111", ResponseCode: 200, OrgID: "org123"}

--- a/pumps/sql_aggregate_test.go
+++ b/pumps/sql_aggregate_test.go
@@ -37,7 +37,7 @@ func TestSQLAggregateInit(t *testing.T) {
 
 }
 
-func TestSQLAggregateWriteDataSharded(t *testing.T) {
+func TestSQLAggregateWriteData_Sharded(t *testing.T) {
 	pmp := SQLAggregatePump{}
 	cfg := make(map[string]interface{})
 	cfg["type"] = "sqlite"


### PR DESCRIPTION
This PR implements table sharding in `SQLAggregatePump`. The logic is a bit different when you compare with other pumps' table sharding. This PR handles everything within one for loop. Also, it doesn't make auto migration separately for the first and second days, instead, it make migration when it is necessary.