### PR TITLE
TT-1032 consider max record for pump when trimming

### DIFF
--- a/main.go
+++ b/main.go
@@ -285,14 +285,15 @@ func writeToPumps(keys []interface{}, job *health.Job, startTime time.Time, purg
 }
 
 func filterData(pump pumps.Pump, keys []interface{}) []interface{} {
+
+	shouldTrim := SystemConfig.MaxRecordSize != 0 || pump.GetMaxRecordSize() != 0
 	filters := pump.GetFilters()
-	if !filters.HasFilter() && !pump.GetOmitDetailedRecording() && SystemConfig.MaxRecordSize == 0 {
+	if !filters.HasFilter() && !pump.GetOmitDetailedRecording() && !shouldTrim {
 		return keys
 	}
 	filteredKeys := keys[:]
 	newLenght := 0
 
-	shouldTrim := SystemConfig.MaxRecordSize != 0 || pump.GetMaxRecordSize() != 0
 	for _, key := range filteredKeys {
 		decoded := key.(analytics.AnalyticsRecord)
 		if pump.GetOmitDetailedRecording() {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
When the max record size for pump is set, then we should trim

## Related Issue
https://tyktech.atlassian.net/browse/TT-1032

## Motivation and Context
fix https://tyktech.atlassian.net/browse/TT-1032

## How This Has Been Tested
- Set max record size in general
- check correct trimming
- Set max record size per pump
- check correct trimimg

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [ ] `go vet`
