### PR TITLE
publish tags in the kafka pump

### DIFF
--- a/pumps/kafka.go
+++ b/pumps/kafka.go
@@ -189,6 +189,7 @@ func (k *KafkaPump) WriteData(ctx context.Context, data []interface{}) error {
 			"host":            decoded.Host,
 			"content_length":  decoded.ContentLength,
 			"user_agent":      decoded.UserAgent,
+			"tags":            decoded.Tags,
 		}
 		//Add static metadata to json
 		for key, value := range k.kafkaConf.MetaData {


### PR DESCRIPTION
Add tags to the Kafka Pump
## Description
Currently, Access logs from Tyk are published to Kafka without tags. On contrary, in the ElasticSearch they are published.

## Motivation and Context
We need this change in our project that uses Tyk and Tyk Pump.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
