### PR TITLE
Update package cloud github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -370,7 +370,7 @@ jobs:
 
       - name: Push to packagecloud
         id: pc-push
-        uses: TykTechnologies/packagecloud-action@main
+        uses: TykTechnologies/packagecloud-action@v1.1
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
         with:


### PR DESCRIPTION
Unblock push to package cloud by updating github action step, m4 template PR is on the way, but blocked by a change to request, lets fix this now.