### PR TITLE
ignore graph analytics for mongo pump(s)

### DIFF
--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -539,7 +539,7 @@ func replaceUnsupportedChars(path string) string {
 }
 
 // AggregateData calculates aggregated data, returns map orgID => aggregated analytics data
-func AggregateData(data []interface{}, trackAllPaths bool, ignoreTagPrefixList []string, storeAnalyticPerMinute bool) map[string]AnalyticsRecordAggregate {
+func AggregateData(data []interface{}, trackAllPaths bool, ignoreTagPrefixList []string, storeAnalyticPerMinute, ignoreGraphData bool) map[string]AnalyticsRecordAggregate {
 	analyticsPerOrg := make(map[string]AnalyticsRecordAggregate)
 	for _, v := range data {
 		thisV := v.(AnalyticsRecord)
@@ -550,7 +550,7 @@ func AggregateData(data []interface{}, trackAllPaths bool, ignoreTagPrefixList [
 		}
 
 		// We don't want to aggregate Graph Data with REST data - there is a different type for that.
-		if thisV.IsGraphRecord() {
+		if ignoreGraphData && thisV.IsGraphRecord() {
 			continue
 		}
 

--- a/analytics/aggregate.go
+++ b/analytics/aggregate.go
@@ -549,6 +549,11 @@ func AggregateData(data []interface{}, trackAllPaths bool, ignoreTagPrefixList [
 			continue
 		}
 
+		// We don't want to aggregate Graph Data with REST data - there is a different type for that.
+		if thisV.IsGraphRecord() {
+			continue
+		}
+
 		thisAggregate, found := analyticsPerOrg[orgID]
 
 		if !found {

--- a/analytics/aggregate_test.go
+++ b/analytics/aggregate_test.go
@@ -57,7 +57,7 @@ func TestAggregate_Tags(t *testing.T) {
 }
 
 func runTestAggregatedTags(t *testing.T, name string, records []interface{}) {
-	aggregations := AggregateData(records, false, []string{}, false)
+	aggregations := AggregateData(records, false, []string{}, false, false)
 
 	t.Run(name, func(t *testing.T) {
 		for _, aggregation := range aggregations {
@@ -80,7 +80,7 @@ func TestAggregateData_SkipGraphRecords(t *testing.T) {
 			for i := range records {
 				data[i] = records[i]
 			}
-			aggregatedData := AggregateData(data, true, nil, true)
+			aggregatedData := AggregateData(data, true, nil, true, true)
 			assert.Equal(t, expectedAggregatedRecordCount, len(aggregatedData))
 			for _, expectedExistingOrgKey := range expectedExistingOrgKeys {
 				_, exists := aggregatedData[expectedExistingOrgKey]

--- a/analytics/aggregate_test.go
+++ b/analytics/aggregate_test.go
@@ -72,3 +72,61 @@ func TestTrimTag(t *testing.T) {
 	assert.Equal(t, "helloworld", TrimTag(".hello.world.."))
 	assert.Equal(t, "hello world", TrimTag(" hello world "))
 }
+
+func TestAggregateData_SkipGraphRecords(t *testing.T) {
+	run := func(records []AnalyticsRecord, expectedAggregatedRecordCount int, expectedExistingOrgKeys []string, expectedNonExistingOrgKeys []string) func(t *testing.T) {
+		return func(t *testing.T) {
+			data := make([]interface{}, len(records))
+			for i := range records {
+				data[i] = records[i]
+			}
+			aggregatedData := AggregateData(data, true, nil, true)
+			assert.Equal(t, expectedAggregatedRecordCount, len(aggregatedData))
+			for _, expectedExistingOrgKey := range expectedExistingOrgKeys {
+				_, exists := aggregatedData[expectedExistingOrgKey]
+				assert.True(t, exists)
+			}
+			for _, expectedNonExistingOrgKey := range expectedNonExistingOrgKeys {
+				_, exists := aggregatedData[expectedNonExistingOrgKey]
+				assert.False(t, exists)
+			}
+		}
+	}
+
+	t.Run("should not skip records if no graph analytics record is present", run(
+		[]AnalyticsRecord{
+			{
+				OrgID: "123",
+				Tags:  []string{"tag_1", "tag_2"},
+			},
+			{
+				OrgID: "987",
+			},
+		},
+		2,
+		[]string{"123", "987"},
+		nil,
+	))
+
+	t.Run("should skip graph analytics records", run([]AnalyticsRecord{
+		{
+			OrgID: "123",
+			Tags:  []string{"tag_1", "tag_2"},
+		},
+		{
+			OrgID: "777-graph",
+			Tags:  []string{"tag_1", "tag_2", PredefinedTagGraphAnalytics},
+		},
+		{
+			OrgID: "987",
+		},
+		{
+			OrgID: "555-graph",
+			Tags:  []string{PredefinedTagGraphAnalytics},
+		},
+	},
+		2,
+		[]string{"123", "987"},
+		[]string{"777-graph", "555-graph"},
+	))
+}

--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -10,11 +10,16 @@ import (
 	"sync/atomic"
 	"time"
 
-	analyticsproto "github.com/TykTechnologies/tyk-pump/analytics/proto"
 	"github.com/oschwald/maxminddb-golang"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	analyticsproto "github.com/TykTechnologies/tyk-pump/analytics/proto"
+
 	"github.com/TykTechnologies/tyk-pump/logger"
+)
+
+const (
+	PredefinedTagGraphAnalytics = "tyk-graph-analytics"
 )
 
 var log = logger.GetLogger()
@@ -323,4 +328,18 @@ func GeoIPLookup(ipStr string, GeoIPDB *maxminddb.Reader) (*GeoData, error) {
 		return nil, fmt.Errorf("geoIPDB lookup of %q failed: %v", ipStr, err)
 	}
 	return record, nil
+}
+
+func (a *AnalyticsRecord) IsGraphRecord() bool {
+	if len(a.Tags) == 0 {
+		return false
+	}
+
+	for _, tag := range a.Tags {
+		if tag == PredefinedTagGraphAnalytics {
+			return true
+		}
+	}
+
+	return false
 }

--- a/analytics/analytics_test.go
+++ b/analytics/analytics_test.go
@@ -1,0 +1,28 @@
+package analytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnalyticsRecord_IsGraphRecord(t *testing.T) {
+	t.Run("should return false when no tags are available", func(t *testing.T) {
+		record := AnalyticsRecord{}
+		assert.False(t, record.IsGraphRecord())
+	})
+
+	t.Run("should return false when tags do not contain the graph analytics tag", func(t *testing.T) {
+		record := AnalyticsRecord{
+			Tags: []string{"tag_1", "tag_2", "tag_3"},
+		}
+		assert.False(t, record.IsGraphRecord())
+	})
+
+	t.Run("should return true when tags contain the graph analytics tag", func(t *testing.T) {
+		record := AnalyticsRecord{
+			Tags: []string{"tag_1", "tag_2", PredefinedTagGraphAnalytics, "tag_4", "tag_5"},
+		}
+		assert.True(t, record.IsGraphRecord())
+	})
+}

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -199,7 +199,7 @@ func (p *HybridPump) WriteData(ctx context.Context, data []interface{}) error {
 		}
 	} else { // send aggregated data
 		// calculate aggregates
-		aggregates := analytics.AggregateData(data, p.trackAllPaths, p.ignoreTagPrefixList, p.storeAnalyticPerMinute)
+		aggregates := analytics.AggregateData(data, p.trackAllPaths, p.ignoreTagPrefixList, p.storeAnalyticPerMinute, false)
 
 		// turn map with analytics aggregates into JSON payload
 		jsonData, err := json.Marshal(aggregates)

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -543,6 +543,11 @@ func (m *MongoPump) AccumulateSet(data []interface{}) [][]interface{} {
 			continue
 		}
 
+		// Skip this record if it is a graph analytics record, they will be handled in a different pump
+		if thisItem.IsGraphRecord() {
+			continue
+		}
+
 		// Add 1 KB for metadata as average
 		sizeBytes := len(thisItem.RawRequest) + len(thisItem.RawResponse) + 1024
 

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -258,7 +258,7 @@ func (m *MongoAggregatePump) WriteData(ctx context.Context, data []interface{}) 
 		m.WriteData(ctx, data)
 	} else {
 		// calculate aggregates
-		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths, m.dbConf.IgnoreTagPrefixList, m.dbConf.StoreAnalyticsPerMinute)
+		analyticsPerOrg := analytics.AggregateData(data, m.dbConf.TrackAllPaths, m.dbConf.IgnoreTagPrefixList, m.dbConf.StoreAnalyticsPerMinute, true)
 
 		// put aggregated data into MongoDB
 		for orgID, filteredData := range analyticsPerOrg {

--- a/pumps/sql_aggregate.go
+++ b/pumps/sql_aggregate.go
@@ -152,7 +152,7 @@ func (c *SQLAggregatePump) WriteData(ctx context.Context, data []interface{}) er
 			table = analytics.AggregateSQLTable
 		}
 
-		analyticsPerOrg := analytics.AggregateData(data[startIndex:endIndex], c.SQLConf.TrackAllPaths, c.SQLConf.IgnoreTagPrefixList, c.SQLConf.StoreAnalyticsPerMinute)
+		analyticsPerOrg := analytics.AggregateData(data[startIndex:endIndex], c.SQLConf.TrackAllPaths, c.SQLConf.IgnoreTagPrefixList, c.SQLConf.StoreAnalyticsPerMinute, false)
 
 		for orgID, ag := range analyticsPerOrg {
 


### PR DESCRIPTION
This PR adds the behavior of ignoring graph analytics records. This means that records that carry the tag `tyk-graph-analytics` won't be stored in the `tyk-analytics` and `tyk_analytics_aggregate` collection (if using default names).

It's a non-breaking change and the new pump to handle graph analytics will be following shortly.

*Why this change?*
Graph records are different from classic REST records. Instead of endpoints graphs are dealing with operations and operation paths. 
HTTP status codes are less relevant for errors, instead, the errors are part of the body response.
All that means that a different struct is necessary to store this data - so we don't need to store graph data in the current collections.

[TT-6121](https://tyktech.atlassian.net/browse/TT-6121)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
