### PR TITLE
TT-6343 Fixing mem address pointer in prom custom metrics

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -178,7 +178,7 @@ func (p *PrometheusPump) Init(conf interface{}) error {
 			if errInit != nil {
 				p.log.Error(errInit)
 			} else {
-				p.log.Info("added custom prometheus metric:",newMetric.Name)
+				p.log.Info("added custom prometheus metric:", newMetric.Name)
 				customMetrics = append(customMetrics, newMetric)
 			}
 		}
@@ -215,7 +215,6 @@ func (p *PrometheusPump) WriteData(ctx context.Context, data []interface{}) erro
 				p.log.Debug("Processing metric:", metric.Name)
 				//we get the values for that metric required labels
 				values := metric.GetLabelsValues(record)
-
 
 				switch metric.MetricType {
 				case COUNTER_TYPE:

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -195,10 +195,10 @@ func (p *PrometheusPump) InitCustomMetrics() error {
 			errInit := newMetric.InitVec()
 			if errInit != nil {
 				return errInit
-			} else {
-				p.log.Info("added custom prometheus metric:", newMetric.Name)
-				customMetrics = append(customMetrics, newMetric)
 			}
+
+			p.log.Info("added custom prometheus metric:", newMetric.Name)
+			customMetrics = append(customMetrics, newMetric)
 		}
 
 		p.allMetrics = append(p.allMetrics, customMetrics...)

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -171,13 +171,14 @@ func (p *PrometheusPump) Init(conf interface{}) error {
 	//then we check the custom ones
 	if len(p.conf.CustomMetrics) > 0 {
 		customMetrics := []*PrometheusMetric{}
-		for _, metric := range p.conf.CustomMetrics {
-			newMetric := &metric
+		for i := range p.conf.CustomMetrics {
+			newMetric := &p.conf.CustomMetrics[i]
 			newMetric.aggregatedObservations = p.conf.AggregateObservations
 			errInit := newMetric.InitVec()
 			if errInit != nil {
 				p.log.Error(errInit)
 			} else {
+				p.log.Info("added custom prometheus metric:",newMetric.Name)
 				customMetrics = append(customMetrics, newMetric)
 			}
 		}
@@ -214,6 +215,7 @@ func (p *PrometheusPump) WriteData(ctx context.Context, data []interface{}) erro
 				p.log.Debug("Processing metric:", metric.Name)
 				//we get the values for that metric required labels
 				values := metric.GetLabelsValues(record)
+
 
 				switch metric.MetricType {
 				case COUNTER_TYPE:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->
Basically, the for loop always took the last memory address of the custom metrics config. That makes the custom metrics always take the last custom metric value. 

Needs to add unit tests before merging.

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-6343
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

Added unit tests - tested manually

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
