### PR TITLE
TT-6482 Histogram type label validation

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -286,7 +286,7 @@ func (pm *PrometheusMetric) InitVec() error {
 			bkts = buckets
 		}
 
-		pm.EnsureLabels()
+		pm.ensureLabels()
 		pm.histogramVec = prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Name:    pm.Name,
@@ -306,7 +306,7 @@ func (pm *PrometheusMetric) InitVec() error {
 }
 
 // EnsureLabels ensure the data validity and consistency of the metric labels
-func (pm *PrometheusMetric) EnsureLabels() {
+func (pm *PrometheusMetric) ensureLabels() {
 	// for histograms we need to be sure that type was added
 	if pm.MetricType == HISTOGRAM_TYPE {
 		typeFound := false

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -310,16 +310,19 @@ func (pm *PrometheusMetric) InitVec() error {
 func (pm *PrometheusMetric) ensureLabels() {
 	// for histograms we need to be sure that type was added
 	if pm.MetricType == HISTOGRAM_TYPE {
-		typeFound := false
+		// remove all references to `type`
+		var i int
 		for _, label := range pm.Labels {
 			if label == "type" {
-				typeFound = true
+				continue
 			}
+			pm.Labels[i] = label
+			i++
 		}
+		pm.Labels = pm.Labels[:i]
 
-		if !typeFound {
-			pm.Labels = append(pm.Labels, "type")
-		}
+		// then add `type` at the beggining
+		pm.Labels = append([]string{"type"}, pm.Labels...)
 	}
 }
 

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -270,7 +270,8 @@ func (p *PrometheusPump) WriteData(ctx context.Context, data []interface{}) erro
 // InitVec inits the prometheus metric based on the metric_type. It only can create counter and histogram,
 // if the metric_type is anything else it returns an error
 func (pm *PrometheusMetric) InitVec() error {
-	if pm.MetricType == COUNTER_TYPE {
+	switch pm.MetricType {
+	case COUNTER_TYPE:
 		pm.counterVec = prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: pm.Name,
@@ -280,7 +281,7 @@ func (pm *PrometheusMetric) InitVec() error {
 		)
 		pm.counterMap = make(map[string]uint64)
 		prometheus.MustRegister(pm.counterVec)
-	} else if pm.MetricType == HISTOGRAM_TYPE {
+	case HISTOGRAM_TYPE:
 		bkts := pm.Buckets
 		if len(bkts) == 0 {
 			bkts = buckets
@@ -297,7 +298,7 @@ func (pm *PrometheusMetric) InitVec() error {
 		)
 		pm.histogramMap = make(map[string]histogramCounter)
 		prometheus.MustRegister(pm.histogramVec)
-	} else {
+	default:
 		return errors.New("invalid metric type:" + pm.MetricType)
 	}
 

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -237,7 +237,6 @@ func (p *PrometheusPump) WriteData(ctx context.Context, data []interface{}) erro
 					if metric.histogramVec != nil {
 						//if the metric is an histogram, we Observe the request time with the given values
 						err := metric.Observe(record.RequestTime, values...)
-						p.log.Infof("\n values: %+v\n", metric)
 						if err != nil {
 							p.log.WithFields(logrus.Fields{
 								"metric_type": metric.MetricType,

--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -321,7 +321,7 @@ func (pm *PrometheusMetric) ensureLabels() {
 		}
 		pm.Labels = pm.Labels[:i]
 
-		// then add `type` at the beggining
+		// then add `type` at the beginning
 		pm.Labels = append([]string{"type"}, pm.Labels...)
 	}
 }

--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -540,11 +540,10 @@ func TestPrometheusCreateBasicMetrics(t *testing.T) {
 }
 
 func TestEnsureLabels(t *testing.T) {
-
 	testCases := []struct {
 		name                 string
-		labels               []string
 		metricType           string
+		labels               []string
 		typeLabelShouldExist bool
 	}{
 		{
@@ -591,8 +590,6 @@ func TestEnsureLabels(t *testing.T) {
 			if tc.typeLabelShouldExist {
 				assert.Equal(t, 1, numberOfTimesOfTypeLabel)
 			}
-
 		})
-
 	}
 }

--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -75,7 +75,7 @@ func TestInitVec(t *testing.T) {
 			} else if tc.customMetric.MetricType == HISTOGRAM_TYPE {
 				assert.NotNil(t, tc.customMetric.histogramVec)
 				assert.Equal(t, tc.isEnabled, prometheus.Unregister(tc.customMetric.histogramVec))
-				assert.Contains(t, tc.customMetric.Labels, "type")
+				assert.Equal(t, tc.customMetric.Labels[0], "type")
 			}
 
 		})
@@ -547,7 +547,7 @@ func TestEnsureLabels(t *testing.T) {
 		typeLabelShouldExist bool
 	}{
 		{
-			name:                 "histogram type, type label should be added",
+			name:                 "histogram type, type label should be added if not exist",
 			labels:               []string{"response_code", "api_name", "method", "api_key", "alias", "path"},
 			metricType:           HISTOGRAM_TYPE,
 			typeLabelShouldExist: true,
@@ -559,8 +559,14 @@ func TestEnsureLabels(t *testing.T) {
 			typeLabelShouldExist: false,
 		},
 		{
-			name:                 "histogram type, type label should not be repeated",
-			labels:               []string{"response_code", "api_name", "method", "api_key", "alias", "path", "type"},
+			name:                 "histogram type, type label should not be repeated and in the 1st position",
+			labels:               []string{"type", "response_code", "api_name", "method", "api_key", "alias", "path"},
+			metricType:           HISTOGRAM_TYPE,
+			typeLabelShouldExist: true,
+		},
+		{
+			name:                 "histogram type, type label should not be repeated (even if user repeated it), and always in the 1st position",
+			labels:               []string{"response_code", "api_name", "type", "method", "api_key", "alias", "path", "type"},
 			metricType:           HISTOGRAM_TYPE,
 			typeLabelShouldExist: true,
 		},
@@ -589,6 +595,8 @@ func TestEnsureLabels(t *testing.T) {
 			// if should exist then it should be only one time
 			if tc.typeLabelShouldExist {
 				assert.Equal(t, 1, numberOfTimesOfTypeLabel)
+				// label `type` should be in the 1st position always
+				assert.Equal(t, pm.Labels[0], "type")
 			}
 		})
 	}

--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -574,7 +574,7 @@ func TestEnsureLabels(t *testing.T) {
 				Labels:     tc.labels,
 			}
 
-			pm.EnsureLabels()
+			pm.ensureLabels()
 			typeLabelFound := false
 			numberOfTimesOfTypeLabel := 0
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Added a function to force `type` to be set when the metric is an histogram

## Related Issue
TT-6482

## Motivation and Context
Do not panic when someone configures an histogram without the label `type`

## How This Has Been Tested
- Ran Pump with the config:
```
{
        "analytics_storage_type": "redis",
    "analytics_storage_config": {
        "type": "redis",
        "host": "tyk-redis",
        "port": 6379,
        "hosts": null,
        "username": "",
        "password": "",
        "database": 0,
        "optimisation_max_idle": 100,
        "optimisation_max_active": 0,
        "enable_cluster": false
    },
    "purge_delay": 2,
    "pumps": {
        "prometheus": {
         "type": "prometheus",
         "meta": {
           "listen_address": "localhost:9090",
           "path": "/metrics",
           "custom_metrics":[
             {
                 "name":"tyk_http_latency",
                 "description":"Latency of API requests",
                 "metric_type":"histogram",
                 "labels":["response_code","api_name","method","api_key","alias","path"]
             }
         ]
         }
        }
    },
    "uptime_pump_config": {
        "collection_name": "tyk_uptime_analytics",
        "mongo_url": "mongodb://tyk-mongo:27017/tyk_analytics",
        "max_insert_batch_size_bytes": 500000,
        "max_document_size_bytes": 200000
    },
    "dont_purge_uptime_data": true
}

```

- Send request to api
- Pump process the record without failing.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
