### PR TITLE
[TT-2485] Support MongoDB Connection argument "readPreference"

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -79,9 +79,7 @@ type BaseMongoConf struct {
 	MongoDBType MongoType `json:"mongo_db_type" mapstructure:"mongo_db_type"`
 	// Set to true to disable the default tyk index creation.
 	OmitIndexCreation bool `json:"omit_index_creation" mapstructure:"omit_index_creation"`
-	// Set the consistency mode for the session, it defaults to `Strong`. The valid values are:
-	// * eventual
-	// monotonic
+	// Set the consistency mode for the session, it defaults to `Strong`. The valid values are: strong, monotonic, eventual.
 	MongoSessionConsistency string `json:"mongo_session_consistency" mapstructure:"mongo_session_consistency"`
 }
 

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -286,18 +286,18 @@ func (m *MongoPump) Init(config interface{}) error {
 	m.log = log.WithField("prefix", mongoPrefix)
 
 	err := mapstructure.Decode(config, &m.dbConf)
+	if err == nil {
+		err = mapstructure.Decode(config, &m.dbConf.BaseMongoConf)
+		m.log.WithFields(logrus.Fields{
+			"url":             m.dbConf.GetBlurredURL(),
+			"collection_name": m.dbConf.CollectionName,
+		}).Info("Init")
+		if err != nil {
+			panic(m.dbConf.BaseMongoConf)
+		}
+	}
 	if err != nil {
 		m.log.Fatal("Failed to decode configuration: ", err)
-	}
-
-	err = mapstructure.Decode(config, &m.dbConf.BaseMongoConf)
-	m.log.WithFields(logrus.Fields{
-		"url":             m.dbConf.GetBlurredURL(),
-		"collection_name": m.dbConf.CollectionName,
-	}).Info("Init")
-
-	if err != nil {
-		panic(m.dbConf.BaseMongoConf)
 	}
 
 	//we check for the environment configuration if this pumps is not the uptime pump

--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -95,6 +95,17 @@ func (b *BaseMongoConf) GetBlurredURL() string {
 	return blurredUrl
 }
 
+func (b *BaseMongoConf) SetMongoConsistency(session *mgo.Session) {
+	switch b.MongoSessionConsistency {
+	case "eventual":
+		session.SetMode(mgo.Eventual, true)
+	case "monotonic":
+		session.SetMode(mgo.Monotonic, true)
+	default:
+		session.SetMode(mgo.Strong, true)
+	}
+}
+
 // @PumpConf Mongo
 type MongoConf struct {
 	// TYKCONFIGEXPAND
@@ -485,14 +496,7 @@ func (m *MongoPump) connect() {
 		m.dbConf.MongoDBType = mongoType(m.dbSession)
 	}
 
-	switch m.dbConf.MongoSessionConsistency {
-	case "eventual":
-		m.dbSession.SetMode(mgo.Eventual, true)
-	case "monotonic":
-		m.dbSession.SetMode(mgo.Monotonic, true)
-	default:
-		m.dbSession.SetMode(mgo.Strong, true)
-	}
+	m.dbConf.SetMongoConsistency(m.dbSession)
 }
 
 func (m *MongoPump) WriteData(ctx context.Context, data []interface{}) error {

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"errors"
+	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -220,6 +221,15 @@ func (m *MongoAggregatePump) connect() {
 
 	if err == nil && m.dbConf.MongoDBType == 0 {
 		m.dbConf.MongoDBType = mongoType(m.dbSession)
+	}
+	fmt.Println("------------------", m.dbConf.MongoSessionConsistency)
+	switch m.dbConf.MongoSessionConsistency {
+	case "eventual":
+		m.dbSession.SetMode(mgo.Eventual, true)
+	case "monotonic":
+		m.dbSession.SetMode(mgo.Monotonic, true)
+	default:
+		m.dbSession.SetMode(mgo.Strong, true)
 	}
 }
 

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	b64 "encoding/base64"
 	"errors"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -222,15 +221,8 @@ func (m *MongoAggregatePump) connect() {
 	if err == nil && m.dbConf.MongoDBType == 0 {
 		m.dbConf.MongoDBType = mongoType(m.dbSession)
 	}
-	fmt.Println("------------------", m.dbConf.MongoSessionConsistency)
-	switch m.dbConf.MongoSessionConsistency {
-	case "eventual":
-		m.dbSession.SetMode(mgo.Eventual, true)
-	case "monotonic":
-		m.dbSession.SetMode(mgo.Monotonic, true)
-	default:
-		m.dbSession.SetMode(mgo.Strong, true)
-	}
+
+	m.dbConf.SetMongoConsistency(m.dbSession)
 }
 
 func (m *MongoAggregatePump) ensureIndexes(c *mgo.Collection) error {

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -121,14 +121,7 @@ func (m *MongoSelectivePump) connect() {
 		m.dbConf.MongoDBType = mongoType(m.dbSession)
 	}
 
-	switch m.dbConf.MongoSessionConsistency {
-	case "eventual":
-		m.dbSession.SetMode(mgo.Eventual, true)
-	case "monotonic":
-		m.dbSession.SetMode(mgo.Monotonic, true)
-	default:
-		m.dbSession.SetMode(mgo.Strong, true)
-	}
+	m.dbConf.SetMongoConsistency(m.dbSession)
 }
 
 func (m *MongoSelectivePump) ensureIndexes(c *mgo.Collection) error {

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -120,6 +120,15 @@ func (m *MongoSelectivePump) connect() {
 	if err == nil && m.dbConf.MongoDBType == 0 {
 		m.dbConf.MongoDBType = mongoType(m.dbSession)
 	}
+
+	switch m.dbConf.MongoSessionConsistency {
+	case "eventual":
+		m.dbSession.SetMode(mgo.Eventual, true)
+	case "monotonic":
+		m.dbSession.SetMode(mgo.Monotonic, true)
+	default:
+		m.dbSession.SetMode(mgo.Strong, true)
+	}
 }
 
 func (m *MongoSelectivePump) ensureIndexes(c *mgo.Collection) error {

--- a/pumps/mongo_selective_test.go
+++ b/pumps/mongo_selective_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/mgo.v2"
 )
 
 func TestMongoSelectivePump_AccumulateSet(t *testing.T) {
@@ -95,4 +96,45 @@ func TestMongoSelectivePump_AccumulateSet(t *testing.T) {
 		99,
 		1024,
 	))
+}
+
+func TestMongoSelectivePump_SessionConsistency(t *testing.T) {
+	mPump := MongoSelectivePump{}
+	conf := defaultSelectiveConf()
+	mPump.dbConf = &conf
+
+	tests := []struct {
+		testName            string
+		sessionConsistency  string
+		expectedSessionMode mgo.Mode
+	}{
+		{
+			testName:            "should set session mode to strong",
+			sessionConsistency:  "strong",
+			expectedSessionMode: mgo.Strong,
+		},
+		{
+			testName:            "should set session mode to monotonic",
+			sessionConsistency:  "monotonic",
+			expectedSessionMode: mgo.Monotonic,
+		},
+		{
+			testName:            "should set session mode to eventual",
+			sessionConsistency:  "eventual",
+			expectedSessionMode: mgo.Eventual,
+		},
+		{
+			testName:            "should set session mode to strong by default",
+			sessionConsistency:  "",
+			expectedSessionMode: mgo.Strong,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			mPump.dbConf.MongoSessionConsistency = test.sessionConsistency
+			mPump.connect()
+			assert.Equal(t, test.expectedSessionMode, mPump.dbSession.Mode())
+		})
+	}
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
## Description
<!-- Describe your changes in detail -->
We're now allowing users to choose the session consistency of their Mongo Pumps (Mongo, Mongo Selective, and Mongo Aggregate).
## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-2485?atlOrigin=eyJpIjoiYWJlZjY4ODBjZTY1NDg1ZmIyZGNiYWM5ZTQ4OTk1NTEiLCJwIjoiaiJ9
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
Users can now determine the replica set focus in the Mongo Cluster. 
They can now choose between:
- `Strong` Default mode. All operations read from the current replica set primary.
- `Monotonic`
  - Before the first write: Read from one of the nearest secondaries if available. Read from primary otherwise.
  - After the first write: same as `strong`.
- `Eventual` Read from one of the nearest members, irrespective of it being primary or secondary. It may change servers between reads.

More info about Mongo's Read Preference [here](https://www.mongodb.com/docs/manual/core/read-preference/#read-preference-modes).
## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->
Unit tests were created for Mongo, Mongo Selective, and Mongo Aggregate.
## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
