### PR TITLE
Merging to release-1.7: using proper semantic for pump version (#537)

### DIFF
--- a/pumps/version.go
+++ b/pumps/version.go
@@ -1,6 +1,6 @@
 package pumps
 
 var (
-	VERSION                    = "v1.7"
+	VERSION                    = "v1.7.0"
 	builtBy, Commit, buildDate string
 )


### PR DESCRIPTION
using proper semantic for pump version (#537)