### PR TITLE
[TT-7961] Remove logrus-prefixed-formatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	github.com/syndtr/goleveldb v0.0.0-20190318030020-c3a204f8e965 // indirect
-	github.com/x-cray/logrus-prefixed-formatter v0.5.2
 	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e

--- a/logger/init.go
+++ b/logger/init.go
@@ -5,24 +5,11 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 var log = logrus.New()
 
 func init() {
-	log.Formatter = GetFormatterWithForcedPrefix()
-}
-
-func GetFormatterWithForcedPrefix() *prefixed.TextFormatter {
-	formatter := new(prefixed.TextFormatter)
-	formatter.TimestampFormat = `Jan 02 15:04:05`
-	formatter.FullTimestamp = true
-
-	return formatter
-}
-
-func GetLogger() *logrus.Logger {
 	level := os.Getenv("TYK_LOGLEVEL")
 
 	switch strings.ToLower(level) {
@@ -36,5 +23,17 @@ func GetLogger() *logrus.Logger {
 		log.Level = logrus.InfoLevel
 	}
 
+	log.Formatter = formatter()
+}
+
+func formatter() *logrus.TextFormatter {
+	formatter := new(logrus.TextFormatter)
+	formatter.TimestampFormat = `Jan 02 15:04:05`
+	formatter.FullTimestamp = true
+	formatter.DisableColors = true
+	return formatter
+}
+
+func GetLogger() *logrus.Logger {
 	return log
 }

--- a/logger/init.go
+++ b/logger/init.go
@@ -10,20 +10,21 @@ import (
 var log = logrus.New()
 
 func init() {
-	level := os.Getenv("TYK_LOGLEVEL")
+	log.Level = level(os.Getenv("TYK_LOGLEVEL"))
+	log.Formatter = formatter()
+}
 
+func level(level string) logrus.Level {
 	switch strings.ToLower(level) {
 	case "error":
-		log.Level = logrus.ErrorLevel
+		return logrus.ErrorLevel
 	case "warn":
-		log.Level = logrus.WarnLevel
+		return logrus.WarnLevel
 	case "debug":
-		log.Level = logrus.DebugLevel
+		return logrus.DebugLevel
 	default:
-		log.Level = logrus.InfoLevel
+		return logrus.InfoLevel
 	}
-
-	log.Formatter = formatter()
 }
 
 func formatter() *logrus.TextFormatter {

--- a/logger/init_test.go
+++ b/logger/init_test.go
@@ -11,7 +11,6 @@ import (
 
 // TestFormatterWithForcedPrefixFileOutput check if the prefix is stored in not TTY outputs
 func TestFormatterWithForcedPrefixFileOutput(t *testing.T) {
-
 	outputFile := "test.log"
 	var f *os.File
 	var err error
@@ -52,7 +51,7 @@ func TestFormatterWithForcedPrefixFileOutput(t *testing.T) {
 	}
 }
 
-func Test_GetLooger(t *testing.T) {
+func Test_GetLogger(t *testing.T) {
 	tests := []struct {
 		name          string
 		env           string
@@ -87,11 +86,9 @@ func Test_GetLooger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("TYK_LOGLEVEL", tt.env)
-			defer os.Unsetenv("TYK_LOGLEVEL")
-			logger := GetLogger()
-			if logger.Level != tt.expectedLevel {
-				t.Errorf("Expected level %v, got %v", tt.expectedLevel, logger.Level)
+			logLevel := level(tt.env)
+			if logLevel != tt.expectedLevel {
+				t.Errorf("Expected level %v, got %v", tt.expectedLevel, logLevel)
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
<!-- Describe your changes in detail -->

1. x-cray is being removed as an indirect gateway dependency, addressing build issues,
2. DisableColor config change removes CVE (TT-4785),
3. moved log.Level modification into init (fixes race condition in GetLogger)

## Related Issue
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!-- Please link to the issue here -->
https://tyktech.atlassian.net/browse/TT-7961

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
<!-- Please describe in detail how you tested your changes -->
<!-- Include details of your testing environment, and the tests you ran to see how your change affects other areas of
the code, etc. -->

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [x] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
