### PR TITLE
Fix: Add less common delimiter for prometheus pump

### DIFF
--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -369,9 +369,9 @@ func TestPrometheusCounterMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 3,
 			expectedMetrics: map[string]uint64{
-				"500--api_1": 2,
-				"200--api_1": 1,
-				"404--api_2": 1,
+				"500\x00api_1": 2,
+				"200\x00api_1": 1,
+				"404\x00api_2": 1,
 			},
 		},
 		{
@@ -392,11 +392,11 @@ func TestPrometheusCounterMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 5,
 			expectedMetrics: map[string]uint64{
-				"500--api_1--test--GET":  2,
-				"500--api_1--test--POST": 1,
-				"500--api_1--test2--GET": 1,
-				"200--api_1--test2--GET": 1,
-				"200--api_2--test--GET":  1,
+				"500\x00api_1\x00test\x00GET":  2,
+				"500\x00api_1\x00test\x00POST": 1,
+				"500\x00api_1\x00test2\x00GET": 1,
+				"200\x00api_1\x00test2\x00GET": 1,
+				"200\x00api_2\x00test\x00GET":  1,
 			},
 		},
 		{
@@ -416,9 +416,9 @@ func TestPrometheusCounterMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 3,
 			expectedMetrics: map[string]uint64{
-				"500--key1": 2,
-				"200--key1": 2,
-				"500--key2": 1,
+				"500\x00key1": 2,
+				"200\x00key1": 2,
+				"500\x00key2": 1,
 			},
 		},
 		{
@@ -438,9 +438,9 @@ func TestPrometheusCounterMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 3,
 			expectedMetrics: map[string]uint64{
-				"500--oauth1": 2,
-				"200--oauth1": 2,
-				"500--oauth2": 1,
+				"500\x00oauth1": 2,
+				"200\x00oauth1": 2,
+				"500\x00oauth2": 1,
 			},
 		},
 		{
@@ -460,10 +460,10 @@ func TestPrometheusCounterMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 4,
 			expectedMetrics: map[string]uint64{
-				"500--api_1--alias1": 2,
-				"500--api_1--alias2": 1,
-				"200--api_1--alias1": 1,
-				"500--api_2--alias1": 1,
+				"500\x00api_1\x00alias1": 2,
+				"500\x00api_1\x00alias2": 1,
+				"200\x00api_1\x00alias1": 1,
+				"500\x00api_2\x00alias1": 1,
 			},
 		},
 	}
@@ -520,12 +520,12 @@ func TestPrometheusHistogramMetric(t *testing.T) {
 			},
 			expectedMetricsAmount: 2,
 			expectedMetrics: map[string]histogramCounter{
-				"total--api_1": {hits: 3, totalRequestTime: 300},
-				"total--api_2": {hits: 1, totalRequestTime: 323},
+				"total\x00api_1": {hits: 3, totalRequestTime: 300},
+				"total\x00api_2": {hits: 1, totalRequestTime: 323},
 			},
 			expectedAverages: map[string]float64{
-				"total--api_1": 100,
-				"total--api_2": 323,
+				"total\x00api_1": 100,
+				"total\x00api_2": 323,
 			},
 		},
 		{
@@ -564,20 +564,20 @@ func TestPrometheusHistogramMetric(t *testing.T) {
 				{APIID: "api_1", Method: "POST", Path: "test", RequestTime: 200},
 				{APIID: "api_2", Method: "GET", Path: "ping", RequestTime: 10},
 				{APIID: "api_2", Method: "GET", Path: "ping", RequestTime: 20},
-				{APIID: "api_2", Method: "GET", Path: "health", RequestTime: 400},
+				{APIID: "api--2", Method: "GET", Path: "health", RequestTime: 400},
 			},
 			expectedMetricsAmount: 4,
 			expectedMetrics: map[string]histogramCounter{
-				"total--api_1--GET--test":   {hits: 2, totalRequestTime: 200},
-				"total--api_1--POST--test":  {hits: 1, totalRequestTime: 200},
-				"total--api_2--GET--ping":   {hits: 2, totalRequestTime: 30},
-				"total--api_2--GET--health": {hits: 1, totalRequestTime: 400},
+				"total\x00api_1\x00GET\x00test":    {hits: 2, totalRequestTime: 200},
+				"total\x00api_1\x00POST\x00test":   {hits: 1, totalRequestTime: 200},
+				"total\x00api_2\x00GET\x00ping":    {hits: 2, totalRequestTime: 30},
+				"total\x00api--2\x00GET\x00health": {hits: 1, totalRequestTime: 400},
 			},
 			expectedAverages: map[string]float64{
-				"total--api_1--GET--test":   100,
-				"total--api_1--POST--test":  200,
-				"total--api_2--GET--ping":   15,
-				"total--api_2--GET--health": 400,
+				"total\x00api_1\x00GET\x00test":    100,
+				"total\x00api_1\x00POST\x00test":   200,
+				"total\x00api_2\x00GET\x00ping":    15,
+				"total\x00api--2\x00GET\x00health": 400,
 			},
 		},
 	}


### PR DESCRIPTION
## Description
In the `Inc` and `Observe` functions, the keys for the counterMap and histogramMap are generated by joining the label values with a double hyphen (--). When the Expose function is called, the keys are split back into label values using the same double hyphen as a separator. The problem occurs because the API name (e.g. test--api-name) or Path (e.g. www.example.com/test/test--123) contains a double hyphen, causing an incorrect split and resulting in a different number of label values than expected.

This causes cardinality error in pump `panic: inconsistent label cardinality: expected 5 label values but got 6` and the pod crashes.

## Related Issue
https://github.com/TykTechnologies/tyk-pump/issues/600

## Motivation and Context
We have a production pump which keeps on crashing due to very same reason

## How This Has Been Tested
Unit tests

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
