### PR TITLE
add the purge logging to resurface pump

### DIFF
--- a/pumps/resurface.go
+++ b/pumps/resurface.go
@@ -233,5 +233,7 @@ func (rp *ResurfacePump) WriteData(ctx context.Context, data []interface{}) erro
 		logger.SendHttpMessage(rp.logger, &resp, &req, decoded.TimeStamp.Unix()*1000, decoded.RequestTime, customFields)
 	}
 
+	rp.log.Info("Purged ", len(data), " records...")
+
 	return nil
 }


### PR DESCRIPTION
Resurface Pump does not have the standard `Purged {X} logs` message that the other pumps do, I've added it