### PR TITLE
Merging to release-1.8: TT-8905 changed the default mongo driver to mgo (#632)

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -347,8 +347,8 @@ func (m *MongoPump) ensureIndexes(collectionName string) error {
 
 func (m *MongoPump) connect() {
 	if m.dbConf.MongoDriverType == "" {
-		// Default to mongo-go
-		m.dbConf.MongoDriverType = persistent.OfficialMongo
+		// Default to mgo
+		m.dbConf.MongoDriverType = persistent.Mgo
 	}
 
 	store, err := persistent.NewPersistentStorage(&persistent.ClientOpts{

--- a/pumps/mongo_aggregate.go
+++ b/pumps/mongo_aggregate.go
@@ -216,8 +216,8 @@ func (m *MongoAggregatePump) connect() {
 	var err error
 
 	if m.dbConf.MongoDriverType == "" {
-		// Default to mongo-go
-		m.dbConf.MongoDriverType = persistent.OfficialMongo
+		// Default to mgo
+		m.dbConf.MongoDriverType = persistent.Mgo
 	}
 
 	m.store, err = persistent.NewPersistentStorage(&persistent.ClientOpts{

--- a/pumps/mongo_aggregate_test.go
+++ b/pumps/mongo_aggregate_test.go
@@ -510,5 +510,5 @@ func TestDefaultDriverAggregate(t *testing.T) {
 	defaultConf.MongoDriverType = ""
 	err := newPump.Init(defaultConf)
 	assert.Nil(t, err)
-	assert.Equal(t, persistent.OfficialMongo, newPump.dbConf.MongoDriverType)
+	assert.Equal(t, persistent.Mgo, newPump.dbConf.MongoDriverType)
 }

--- a/pumps/mongo_selective.go
+++ b/pumps/mongo_selective.go
@@ -114,8 +114,8 @@ func (m *MongoSelectivePump) connect() {
 	var err error
 
 	if m.dbConf.MongoDriverType == "" {
-		// Default to mongo-go
-		m.dbConf.MongoDriverType = persistent.OfficialMongo
+		// Default to mgo
+		m.dbConf.MongoDriverType = persistent.Mgo
 	}
 
 	m.store, err = persistent.NewPersistentStorage(&persistent.ClientOpts{

--- a/pumps/mongo_selective_test.go
+++ b/pumps/mongo_selective_test.go
@@ -389,5 +389,5 @@ func TestDefaultDriverSelective(t *testing.T) {
 	defaultConf.MongoDriverType = ""
 	err := newPump.Init(defaultConf)
 	assert.Nil(t, err)
-	assert.Equal(t, persistent.OfficialMongo, newPump.dbConf.MongoDriverType)
+	assert.Equal(t, persistent.Mgo, newPump.dbConf.MongoDriverType)
 }

--- a/pumps/mongo_test.go
+++ b/pumps/mongo_test.go
@@ -563,5 +563,5 @@ func TestDefaultDriver(t *testing.T) {
 	defaultConf.MongoDriverType = ""
 	err := newPump.Init(defaultConf)
 	assert.Nil(t, err)
-	assert.Equal(t, persistent.OfficialMongo, newPump.dbConf.MongoDriverType)
+	assert.Equal(t, persistent.Mgo, newPump.dbConf.MongoDriverType)
 }


### PR DESCRIPTION
TT-8905 changed the default mongo driver to mgo (#632)

* changed the default mongo driver to mgo

* change log msg to point mgo