### PR TITLE
Merging to release-1.8: [TT-8884]: added write data test for mongo pump and remove constraint (#645)

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -384,7 +384,7 @@ func (m *MongoPump) WriteData(ctx context.Context, data []interface{}) error {
 
 	m.log.Debug("Attempting to write ", len(data), " records...")
 
-	accumulateSet := m.AccumulateSet(data, true)
+	accumulateSet := m.AccumulateSet(data, false)
 
 	errCh := make(chan error, len(accumulateSet))
 	for _, dataSet := range accumulateSet {
@@ -456,7 +456,7 @@ func (m *MongoPump) AccumulateSet(data []interface{}, isForGraphRecords bool) []
 
 // shouldProcessItem checks if the item should be processed based on its ResponseCode and if it's a graph record.
 // It returns the processed item and a boolean indicating if the item should be skipped.
-func (m *MongoPump) shouldProcessItem(item interface{}, isForGraphRecords bool) (*analytics.AnalyticsRecord, bool) {
+func (m *MongoPump) shouldProcessItem(item interface{}, isForGraphRecords bool) (records *analytics.AnalyticsRecord, shouldSKip bool) {
 	thisItem, ok := item.(analytics.AnalyticsRecord)
 	if !ok {
 		m.log.Error("Couldn't convert item to analytics.AnalyticsRecord")
@@ -467,10 +467,9 @@ func (m *MongoPump) shouldProcessItem(item interface{}, isForGraphRecords bool) 
 	}
 
 	isGraphRecord := thisItem.IsGraphRecord()
-	if isGraphRecord != isForGraphRecords {
+	if isForGraphRecords && !isGraphRecord {
 		return &thisItem, true
 	}
-
 	return &thisItem, false
 }
 

--- a/pumps/mongo_test.go
+++ b/pumps/mongo_test.go
@@ -7,6 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/vmihailenco/msgpack.v2"
 
@@ -319,17 +323,10 @@ func TestMongoPump_AccumulateSet(t *testing.T) {
 			mPump.log = log.WithField("prefix", mongoPrefix)
 
 			data := recordsGenerator(numRecords)
-			expectedGraphRecordSkips := 0
-			for _, recordData := range data {
-				record := recordData.(analytics.AnalyticsRecord)
-				if record.IsGraphRecord() {
-					expectedGraphRecordSkips++
-				}
-			}
 
 			// assumed from sizeBytes in AccumulateSet
 			const dataSize = 1024
-			totalData := dataSize * (numRecords - expectedGraphRecordSkips)
+			totalData := dataSize * (numRecords)
 
 			set := mPump.AccumulateSet(data, false)
 
@@ -357,7 +354,7 @@ func TestMongoPump_AccumulateSet(t *testing.T) {
 		100,
 	))
 
-	t.Run("should skip all graph analytics records", run(
+	t.Run("should include all graph analytics records", run(
 		func(numRecords int) []interface{} {
 			data := make([]interface{}, 0)
 			for i := 0; i < numRecords; i++ {
@@ -369,7 +366,7 @@ func TestMongoPump_AccumulateSet(t *testing.T) {
 			}
 			return data
 		},
-		50,
+		100,
 	))
 }
 
@@ -564,4 +561,92 @@ func TestDefaultDriver(t *testing.T) {
 	err := newPump.Init(defaultConf)
 	assert.Nil(t, err)
 	assert.Equal(t, persistent.Mgo, newPump.dbConf.MongoDriverType)
+}
+
+func TestMongoPump_WriteData(t *testing.T) {
+	sampleRecord := analytics.AnalyticsRecord{
+		Method:       "GET",
+		Host:         "localhost:9000",
+		Path:         "/test",
+		Day:          1,
+		Month:        1,
+		Year:         2023,
+		ResponseCode: 200,
+		APIKey:       "testkey",
+		TimeStamp:    time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		APIName:      "testapi",
+		APIID:        "testapi",
+		OrgID:        "testorg",
+		Geo: analytics.GeoData{
+			City: analytics.City{
+				Names: map[string]string{},
+			},
+		},
+		Tags: []string{},
+	}
+
+	run := func(recordGenerator func(count int) []analytics.AnalyticsRecord) func(t *testing.T) {
+		return func(t *testing.T) {
+			pump := &MongoPump{}
+			conf := defaultConf()
+			pump.dbConf = &conf
+			pump.log = log.WithField("prefix", mongoPrefix)
+
+			pump.connect()
+
+			t.Cleanup(func() {
+				if err := pump.store.DropDatabase(context.Background()); err != nil {
+					pump.log.WithError(err).Warn("error dropping collection")
+				}
+			})
+
+			data := recordGenerator(100)
+			interfaceRecords := make([]interface{}, len(data))
+			for i, d := range data {
+				interfaceRecords[i] = d
+			}
+
+			err := pump.WriteData(context.Background(), interfaceRecords)
+			require.NoError(t, err)
+
+			var results []analytics.AnalyticsRecord
+
+			// Using the same collection name as the default pump config
+			d := dbObject{
+				tableName: pump.dbConf.CollectionName,
+			}
+			err = pump.store.Query(context.Background(), d, &results, nil)
+
+			assert.Nil(t, err)
+
+			// ensure the length and content are the same
+			assert.Equal(t, len(data), len(results))
+			if diff := cmp.Diff(data, results, cmpopts.IgnoreFields(analytics.AnalyticsRecord{}, "id", "APISchema")); diff != "" {
+				t.Error(diff)
+			}
+		}
+	}
+
+	t.Run("should write all records", run(func(count int) []analytics.AnalyticsRecord {
+		records := make([]analytics.AnalyticsRecord, count)
+		for i := range records {
+			records[i] = sampleRecord
+		}
+		return records
+	}))
+
+	t.Run("should write graph records as well", run(func(count int) []analytics.AnalyticsRecord {
+		records := make([]analytics.AnalyticsRecord, count)
+		for i := range records {
+			record := sampleRecord
+			if i%2 == 0 {
+				record.RawRequest = rawGQLRequest
+				record.RawResponse = rawGQLResponse
+				record.APISchema = schema
+				record.Tags = []string{analytics.PredefinedTagGraphAnalytics}
+			}
+			records[i] = record
+		}
+		return records
+	}))
 }


### PR DESCRIPTION
[TT-8884]: added write data test for mongo pump and remove constraint (#645)

* added write data test for mongo pump and remove constraint

Added a test to cover the write data function of the mongo pump, and
removed a bug where he mongo pump only recorded graph records

* run fmt