### PR TITLE
TT-9228 update regex to blur mongo credentials

### DIFF
--- a/pumps/mongo.go
+++ b/pumps/mongo.go
@@ -112,9 +112,9 @@ func createDBObject(tableName string) dbObject {
 }
 
 func (b *BaseMongoConf) GetBlurredURL() string {
-	// mongo uri match with regex ^(mongodb:(?:\/{2})?)((\w+?):(\w+?)@|:?@?)(\S+?):(\d+)(\/(\S+?))?(\?replicaSet=(\S+?))?$
-	// but we need only a segment, so regex explanation: https://regex101.com/r/8Uzwtw/1
-	regex := `^(mongodb:(?:\/{2})?)((...+?):(...+?)@)`
+	// mongo uri match with regex ^(mongodb\S*(+srv)*:(?:\/{2})?)((\w+?):(\w+?)@|:?@?)(\S+?):(\d+)(\/(\S+?))?(\?replicaSet=(\S+?))?$
+	// but we need only a segment, so regex explanation: https://regex101.com/r/C4GQvi/1
+	regex := `^(mongodb\S*(srv)*:(?:\/{2})?)((...+?):(...+?)@)`
 	re := regexp.MustCompile(regex)
 
 	blurredUrl := re.ReplaceAllString(b.MongoURL, "***:***@")

--- a/pumps/mongo_test.go
+++ b/pumps/mongo_test.go
@@ -459,6 +459,11 @@ func TestGetBlurredURL(t *testing.T) {
 			givenURL:           "mongodb://UserName:Password@sample-cluster-instance.cluster-corlsfccjozr.us-east-1.docdb.amazonaws.com:27017?replicaSet=rs0&ssl_ca_certs=rds-combined-ca-bundle.pem",
 			expectedBlurredURL: "***:***@sample-cluster-instance.cluster-corlsfccjozr.us-east-1.docdb.amazonaws.com:27017?replicaSet=rs0&ssl_ca_certs=rds-combined-ca-bundle.pem",
 		},
+		{
+			testName:           "DNS seed list connection",
+			givenURL:           "mongodb+srv://admin:pass@server.example.com/?connectTimeoutMS=300000",
+			expectedBlurredURL: "***:***@server.example.com/?connectTimeoutMS=300000",
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

## Description
Updated the regex in charge of matching the mongo connection strings, so it receives in the srv format and the blurred is done in the user:pass section

## Related Issue
https://tyktech.atlassian.net/browse/TT-9228

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->

## How This Has Been Tested
- Added unit test
- Validated against regex validator

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
