### PR TITLE
TT-10676 Upgrade Resurface Pump backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
 	github.com/quipo/statsd v0.0.0-20160923160612-75b7afedf0d2
-	github.com/resurfaceio/logger-go/v3 v3.2.1
+	github.com/resurfaceio/logger-go/v3 v3.3.2
 	github.com/robertkowalski/graylog-golang v0.0.0-20151121031040-e5295cfa2827
 	github.com/segmentio/analytics-go v0.0.0-20160711225931-bdb0aeca8a99
 	github.com/segmentio/kafka-go v0.3.6
@@ -53,6 +53,7 @@ require (
 	github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d // indirect
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.5.0 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
+github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
+github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
@@ -451,8 +453,8 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/quipo/statsd v0.0.0-20160923160612-75b7afedf0d2 h1:IvjiJDGCF8L8TjKHQKmLAjWztpKDCAaRifiRMdGzWk0=
 github.com/quipo/statsd v0.0.0-20160923160612-75b7afedf0d2/go.mod h1:1COUodqytMiv/GkAVUGhc0CA6e8xak5U4551TY7iEe0=
-github.com/resurfaceio/logger-go/v3 v3.2.1 h1:tTPvGp+FpH35aaT/nnhP4n/Rh/f1vHe64WoXTDgv0fY=
-github.com/resurfaceio/logger-go/v3 v3.2.1/go.mod h1:YPcxFUcloW37F1WQA9MUcGWu2JzlvBxlCfFF5+T3GO8=
+github.com/resurfaceio/logger-go/v3 v3.3.2 h1:bUjzvNM/g7Qcy8r3ctA71lCFf9gmpEghovmN125XXRs=
+github.com/resurfaceio/logger-go/v3 v3.3.2/go.mod h1:ZswfY9nja+SfeAZiFnbFR1aHk7WCDR0is/NWvId7oT0=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/robertkowalski/graylog-golang v0.0.0-20151121031040-e5295cfa2827 h1:D2Xs0bSuqpKnUOOlK4yu6lloeOs4+oD+pjbOfsxgWu0=
 github.com/robertkowalski/graylog-golang v0.0.0-20151121031040-e5295cfa2827/go.mod h1:jONcYFk83vUF1lv0aERAwaFtDM9wUW4BMGmlnpLJyZY=

--- a/pumps/resurface.go
+++ b/pumps/resurface.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/mitchellh/mapstructure"
@@ -17,8 +18,11 @@ import (
 )
 
 type ResurfacePump struct {
-	logger *logger.HttpLogger
-	config *ResurfacePumpConfig
+	logger  *logger.HttpLogger
+	config  *ResurfacePumpConfig
+	data    chan []interface{}
+	wg      sync.WaitGroup
+	enabled bool
 	CommonPumpConfig
 }
 
@@ -49,6 +53,7 @@ func (rp *ResurfacePump) GetEnvPrefix() string {
 }
 
 func (rp *ResurfacePump) Init(config interface{}) error {
+	rp.wg = sync.WaitGroup{}
 	rp.config = &ResurfacePumpConfig{}
 	rp.log = log.WithField("prefix", resurfacePrefix)
 
@@ -74,8 +79,24 @@ func (rp *ResurfacePump) Init(config interface{}) error {
 		rp.log.Info(rp.GetName() + " Initialized (Logger disabled)")
 		return errors.New("logger is not enabled")
 	}
+	rp.initWorker()
 	rp.log.Info(rp.GetName() + " Initialized")
 	return nil
+}
+
+func (rp *ResurfacePump) initWorker() {
+	rp.data = make(chan []interface{}, 5)
+	rp.wg.Add(1)
+	go rp.writeData()
+	rp.enable()
+}
+
+func (rp *ResurfacePump) disable() {
+	rp.enabled = false
+}
+
+func (rp *ResurfacePump) enable() {
+	rp.enabled = true
 }
 
 func parseHeaders(headersString string, existingHeaders http.Header) (headers http.Header) {
@@ -210,30 +231,70 @@ func mapRawData(rec *analytics.AnalyticsRecord) (httpReq http.Request, httpResp 
 	return
 }
 
+func (rp *ResurfacePump) writeData() {
+	defer rp.wg.Done()
+	for data := range rp.data {
+		for _, v := range data {
+			decoded, ok := v.(analytics.AnalyticsRecord)
+			if !ok {
+				rp.log.Error("Error decoding analytic record")
+				continue
+			}
+			if len(decoded.RawRequest) == 0 && len(decoded.RawResponse) == 0 {
+				rp.log.Warn("Record dropped. Please enable Detailed Logging.")
+				continue
+			}
+
+			req, resp, customFields, err := mapRawData(&decoded)
+			if err != nil {
+				rp.log.Error(err)
+				continue
+			}
+
+			logger.SendHttpMessage(rp.logger, &resp, &req, decoded.TimeStamp.Unix()*1000, decoded.RequestTime, customFields)
+		}
+		rp.log.Info("Wrote ", len(data), " records...")
+	}
+}
+
 func (rp *ResurfacePump) WriteData(ctx context.Context, data []interface{}) error {
 	rp.log.Debug("Writing ", len(data), " records")
-
-	for _, v := range data {
-		decoded, ok := v.(analytics.AnalyticsRecord)
-		if !ok {
-			rp.log.Error("Error decoding analytic record")
-			continue
+	if rp.enabled {
+		rp.data <- data
+		rp.log.Info("Purged ", len(data), " records...")
+	} else {
+		select {
+		case peek, open := <-rp.data:
+			if open {
+				rp.data <- peek
+				close(rp.data)
+			}
+		default:
+			close(rp.data)
 		}
-		if len(decoded.RawRequest) == 0 && len(decoded.RawResponse) == 0 {
-			rp.log.Warn("Record dropped. Please enable Detailed Logging.")
-			continue
-		}
-
-		req, resp, customFields, err := mapRawData(&decoded)
-		if err != nil {
-			rp.log.Error(err)
-			continue
-		}
-
-		logger.SendHttpMessage(rp.logger, &resp, &req, decoded.TimeStamp.Unix()*1000, decoded.RequestTime, customFields)
 	}
+	return nil
+}
 
-	rp.log.Info("Purged ", len(data), " records...")
+func (rp *ResurfacePump) Flush() error {
+	rp.disable()
+	err := rp.WriteData(context.TODO(), []interface{}{})
+	if err != nil {
+		return err
+	}
+	rp.wg.Wait()
+	rp.initWorker()
+
+	return nil
+}
+
+func (rp *ResurfacePump) Shutdown() error {
+	rp.logger.Stop()
+
+	err := rp.Flush()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/pumps/resurface_test.go
+++ b/pumps/resurface_test.go
@@ -121,7 +121,10 @@ func TestResurfaceWriteData(t *testing.T) {
 	}
 
 	err := pmp.WriteData(context.TODO(), recs)
-	assert.Nil(t, err, pmp.GetName()+"couldn't write records")
+	assert.Nil(t, err, pmp.GetName()+" couldn't write records")
+
+	err = pmp.Flush()
+	assert.Nil(t, err, pmp.GetName()+" couldn't flush records")
 
 	queue := pmp.logger.Queue()
 	assert.Equal(t, len(recs), len(queue))
@@ -162,7 +165,10 @@ func TestResurfaceWriteData(t *testing.T) {
 			TimeStamp:    time.Now(),
 		},
 	})
-	assert.Nil(t, err, pmp.GetName()+"couldn't write records")
+	assert.Nil(t, err, pmp.GetName()+" couldn't write records")
+
+	err = pmp.Flush()
+	assert.Nil(t, err, pmp.GetName()+" couldn't flush records")
 
 	queue = pmp.logger.Queue()
 	assert.Equal(t, len(recs)+1, len(queue))
@@ -231,7 +237,10 @@ func TestResurfaceWriteCustomFields(t *testing.T) {
 	}
 
 	err := pmp.WriteData(context.TODO(), recs)
-	assert.Nil(t, err, pmp.GetName()+"couldn't write records")
+	assert.Nil(t, err, pmp.GetName()+" couldn't write records")
+
+	err = pmp.Flush()
+	assert.Nil(t, err, pmp.GetName()+" couldn't flush records")
 
 	queue := pmp.logger.Queue()
 	assert.Equal(t, len(recs), len(queue))
@@ -284,9 +293,10 @@ func TestResurfaceWriteChunkedResponse(t *testing.T) {
 	}
 
 	err := pmp.WriteData(context.TODO(), recs)
-	if err != nil {
-		t.Fatal(pmp.GetName()+"couldn't write records with err:", err)
-	}
+	assert.Nil(t, err, pmp.GetName()+" couldn't write records")
+
+	err = pmp.Flush()
+	assert.Nil(t, err, pmp.GetName()+" couldn't flush records")
 
 	queue := pmp.logger.Queue()
 	assert.Equal(t, len(recs), len(queue))
@@ -319,7 +329,10 @@ func TestResurfaceSkipWrite(t *testing.T) {
 	}
 
 	err := pmp.WriteData(context.TODO(), recs)
-	assert.Nil(t, err, pmp.GetName()+"couldn't write records")
+	assert.Nil(t, err, pmp.GetName()+" couldn't write records")
+
+	err = pmp.Flush()
+	assert.Nil(t, err, pmp.GetName()+" couldn't flush records")
 
 	queue := pmp.logger.Queue()
 	assert.Equal(t, 0, len(queue))


### PR DESCRIPTION
Upgrade the [Resurface backend](https://github.com/TykTechnologies/tyk-pump/blob/master/pumps/resurface.go) for the Tyk Pump. This upgrade makes the data writing process asynchronous through the use of bounded channels. In addition, the `Shutdown` method has been defined to support graceful shutdown.

## Description
- Upgrade `logger-go` dependency to version 3.3.1, which includes improvements in goroutine management, as well as a new `Stop` method for graceful shutdown.
- Add support for async data writing, by adding a bounded channel to buffer data records and process them concurrently in the background.
- Add `Shutdown` method for graceful shutdown of `ResurfacePump` backend.

## Related Issue
Issues #729 and #730 

## Motivation and Context
- Version 3.2.1 of the logger-go dependency is susceptible to memory runaway issues under heavy load. Version 3.3.1 provides a fix for this problem, as well as a new `Stop` method for graceful shutdown of the data capture process.
- With synchronous record processing, `WriteData` might take a long time to return (e.g. longer than the configured redis TTL). This can be a bottleneck that can affect the entire data capture process.

## How This Has Been Tested
- Clone [Tyk Pro demo](https://github.com/TykTechnologies/tyk-pro-docker-demo) repo
- Add both Resurface and HTTP Bin services to the `docker-compose.yml` file:
```yaml
  tyk-resurface:
    image: resurfaceio/resurface:3.5.4
    container_name: tyk-resurface
    ports:
      - "7700:7700"
      - "7701:7701"
    tmpfs:
      - /db
    networks:
      - tyk

  tyk-httpbin:
    image: kennethreitz/httpbin
    container_name: tyk-httpbin
    ports:
      - "80:80"
    networks:
      - tyk
```
- Modify the `pump.conf` file to configure the Resurface pump backend **without any timeout**:
```json
    "resurfaceio": {
      "type": "resurfaceio",
      "meta": {
        "capture_url": "http://tyk-resurface:7701/message",
        "rules": "include debug"
      }
    }
```
- Import the following HTTP Bin Tyk API definition:
```json
{
    "name": "httpbin",
    "slug": "httpbin",
    "api_id": "httpbin-api",
    "org_id": "test-org",
    "use_keyless": true,
    "version_data": {
        "not_versioned": true,
        "versions": {
            "Default": {
                "name": "Default",
                "expires": ""
            }
        }
    },
    "proxy": {
        "listen_path": "/http-bin/",
        "target_url": "http://httpbin"
    },
    "active": true,
    "enable_detailed_recording": true
}
```
- Use a load testing application like [Locust](https://locust.io/) or [bombardier](https://github.com/codesenberg/bombardier) to send a several concurrent requests to the `/image/png` endpoint aiming for >4000 RPS (Configurations used: Locust: 2 workers, 50 spawn rate, and 6000 users; Bombardier: concurrency level of 100 with 500k requests)
- Wait for a few minutes. If using the current Tyk Pump release: the number of purged records will start to build up to a point where the pump can't keep up with the new records being generated. The gaps created by this issue will be reflected in Resurface. No errors or gaps are present when performing the same test with the changes introduced by this PR.

## Screenshots (if appropriate)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`
