### PR TITLE
run release every monday

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@
 name: Release
 
 on:
+  # Trigger release every monday at midnight for master CI images
+  schedule:
+    - cron: "0 0 * * 1"  
   pull_request:
   push:
     branches:


### PR DESCRIPTION
We need to keep master CI image uploaded to the AWS registry. Given the unability to setup a flexible policy for registry cleanup we need to refresh images.