### PR TITLE
Merging to release-1.9: [TT-10673] Upgrading to Go 1.21 (#766)

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         redis-version: [5]
         mongodb-version: [4.2]
-        go: [1.19]
+        go: [1.21]
 
     steps:
       - name: Checkout Tyk Pump

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.19]
+        go: [1.21]
     with:
       go: ${{ matrix.go }}
       redis: 5
@@ -34,7 +34,7 @@ jobs:
     uses: TykTechnologies/github-actions/.github/workflows/golangci.yaml@main
     with:
       main_branch: "master"
-      go_version: 1.19
+      go_version: 1.21
   sonarcloud:
     if: ${{ always() }}
     needs: [gotest, golangci]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.19-bullseye 
+          - 1.21-bullseye 
         include: 
-          - golang_cross: 1.19-bullseye
+          - golang_cross: 1.21-bullseye
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo:  0  
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -124,13 +124,13 @@ jobs:
 
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.19-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
         with:
           mask-password: 'true'
 
       - name: Docker metadata for CI
         id: metadata
-        if: ${{ matrix.golang_cross == '1.19-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.ecr.outputs.registry }}/tyk-pump
@@ -144,7 +144,7 @@ jobs:
             type=semver,pattern=v{{version}},prefix=v
 
       - name: CI push
-        if: ${{ matrix.golang_cross == '1.19-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
         shell: bash
         env:
           t: ${{ steps.metadata.outputs.tags }}
@@ -160,7 +160,7 @@ jobs:
           done
 
       - uses: actions/upload-artifact@v3
-        if: ${{ matrix.golang_cross == '1.19-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
         with:
           name: deb
           retention-days: 1
@@ -169,7 +169,7 @@ jobs:
             !dist/*PAYG*.deb
 
       - uses: actions/upload-artifact@v3
-        if: ${{ matrix.golang_cross == '1.19-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.21-bullseye' }}
         with:
           name: rpm
           retention-days: 1

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -25,12 +25,10 @@ linters:
     - govet
     - gosec
     - ineffassign
-#    - lll
     - misspell
     - revive
     - staticcheck
     - whitespace
-#    - wsl
 
 linters-settings:
   auto-fix: true
@@ -65,7 +63,7 @@ linters-settings:
     extra-rules: true
 
     # Select the Go version to target.
-    lang-version: "1.19"
+    lang-version: "1.21"
 
   goimports:
     auto-fix: false
@@ -79,7 +77,7 @@ linters-settings:
     enable-all: true
 
   lll:
-    auto-fix: true  
+    auto-fix: true
     # Max line length; lines longer will be reported
     # '\t' is counted as 1 character by default, and can be changed with the 'tab-width' option
     line-length: 120
@@ -102,7 +100,7 @@ linters-settings:
     # https://staticcheck.io/docs/options#checks
     checks: ["all"]
     # Select the Go version to target.
-    go: "1.19"
+    go: "1.21"
 
   whitespace:
     auto-fix: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TykTechnologies/tyk-pump
 
-go 1.19
+go 1.21
 
 require (
 	github.com/DataDog/datadog-go v4.7.0+incompatible

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-
 	"os"
 	"os/signal"
 	"sync"
@@ -28,9 +27,11 @@ func (p *MockedPump) GetName() string {
 func (p *MockedPump) New() pumps.Pump {
 	return &MockedPump{}
 }
+
 func (p *MockedPump) Init(config interface{}) error {
 	return nil
 }
+
 func (p *MockedPump) WriteData(ctx context.Context, keys []interface{}) error {
 	for range keys {
 		p.CounterRequest++
@@ -44,7 +45,6 @@ func (p *MockedPump) Shutdown() error {
 }
 
 func TestFilterData(t *testing.T) {
-
 	mockedPump := &MockedPump{}
 
 	mockedPump.SetFilters(
@@ -62,12 +62,10 @@ func TestFilterData(t *testing.T) {
 	if len(keys) == len(filteredKeys) {
 		t.Fatal("keys and filtered keys have the  same lenght")
 	}
-
 }
 
 // TestTrimData check the correct functionality of max_record_size
 func TestTrimData(t *testing.T) {
-
 	loremIpsum := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
 
 	tcs := []struct {
@@ -226,11 +224,11 @@ func TestWriteDataWithFilters(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
+		tc := tc
 		t.Run(tc.testName, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.expectedCounterRequest, tc.mockedPump.CounterRequest)
 			assert.Len(t, keys, 6)
-
 		})
 	}
 }

--- a/repo-policy/main.tf
+++ b/repo-policy/main.tf
@@ -49,7 +49,7 @@ module "tyk-pump" {
     { branch    = "master",
       reviewers = "1",
       convos    = "false",
-    required_tests = ["1.19-bullseye", "Go 1.19 tests", "api-tests (sha256, mongo44)", "api-tests (sha256, postgres15)", "api-tests (murmur64, mongo44)", "api-tests (murmur64, postgres15)"] },
+    required_tests = ["1.21-bullseye", "Go 1.21 tests", "api-tests (sha256, mongo44)", "api-tests (sha256, postgres15)", "api-tests (murmur64, mongo44)", "api-tests (murmur64, postgres15)"] },
     { branch        = "release-1.8",
       reviewers     = "0",
       convos        = "false",


### PR DESCRIPTION
[TT-10673] Upgrading to Go 1.21 (#766)

* upgrading to Go 1.21

* fixing loop issue

* removing comment

* linting

* add release 1.19 revert 1.18 req tests

* removing commented linters

* removing 1.19 branch from terraform

---------

Co-authored-by: Esteban Ricardo Mirizio <ermirizio@gmail.com>

[TT-10673]: https://tyktech.atlassian.net/browse/TT-10673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ