### PR TITLE
[SYSE-336 master] Followup from March template application

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,22 +88,22 @@ jobs:
           docker run --rm --privileged -e GITHUB_TOKEN=${{ github.token }} \
           -e GOPRIVATE=github.com/TykTechnologies                                \
           -e GO111MODULE=on \
-          -e DEBVERS='${{ matrix.debvers }}' 	      	      	         \
-          -e RPMVERS='${{ matrix.rpmvers }}' 				 \
-          -e CGO_ENABLED=${{ matrix.cgo }}  				 \
-          -e NFPM_STD_PASSPHRASE="$NFPM_STD_PASSPHRASE" 			 \
-          -e GPG_FINGERPRINT=12B5D62C28F57592D1575BD51ED14C59E37DAC20 		 \
-          -e PKG_SIGNING_KEY="$PKG_SIGNING_KEY" 				 \
-          -e PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN 				 \
+          -e DEBVERS='${{ matrix.debvers }}'                               \
+          -e RPMVERS='${{ matrix.rpmvers }}'                               \
+          -e CGO_ENABLED=${{ matrix.cgo }}                                 \
+          -e NFPM_STD_PASSPHRASE="$NFPM_STD_PASSPHRASE"                          \
+          -e GPG_FINGERPRINT=12B5D62C28F57592D1575BD51ED14C59E37DAC20            \
+          -e PKG_SIGNING_KEY="$PKG_SIGNING_KEY"                                  \
+          -e PACKAGECLOUD_TOKEN=$PACKAGECLOUD_TOKEN                              \
           -v ${{github.workspace}}:/go/src/github.com/TykTechnologies/tyk-pump \
-          -v /var/run/docker.sock:/var/run/docker.sock 			         \
-          -v ~/.docker/config.json:/root/.docker/config.json 			 \
-          -e GOCACHE=/cache/go-build 						 \
-          -e GOMODCACHE=/go/pkg/mod 						 \
-          -v ~/go/pkg/mod:/go/pkg/mod 						 \
-          -v ~/.cache/go-build:/cache/go-build 					 \
-          -v /tmp/build.sh:/tmp/build.sh 					 \
-          -w /go/src/github.com/TykTechnologies/tyk-pump 			 \
+          -v /var/run/docker.sock:/var/run/docker.sock                           \
+          -v ~/.docker/config.json:/root/.docker/config.json                     \
+          -e GOCACHE=/cache/go-build                                             \
+          -e GOMODCACHE=/go/pkg/mod                                              \
+          -v ~/go/pkg/mod:/go/pkg/mod                                            \
+          -v ~/.cache/go-build:/cache/go-build                                   \
+          -v /tmp/build.sh:/tmp/build.sh                                         \
+          -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - uses: aws-actions/configure-aws-credentials@v4
         with:


### PR DESCRIPTION
Learning from the application:
Applying templates across all branches and repos runs up against the usage limits. Larger runners are available for Team plans. This needs to be explored.
A local run of release.yml is needed to test updates before pushing it to all repos and waiting for >30mins to find out if it works.
For regular updates which collect disparate code changes, the git commit log in the repos should reflect a summary of changes that went into it.
- [x] Mount go package and build cache into build container
- [x] nektos/act for local runs
- [x] dependabot alerts @devops for only .g/w/release.yml
- [x] r5-lts to test against pump and sink master
- [x] Larger runners for Actions
- [x] pk for byol build
- [x] Converge UI and API tests compose environments in tyk-ci
