### PR TITLE
[SYSE-353 master] Fix tyk-ci fetch mechanism

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release download v1.2 --repo github.com/TykTechnologies/tyk-ci -O env.tgz
+          gh release download --repo github.com/TykTechnologies/tyk-ci -p 'ci-env.tgz' -O env.tgz
           tar xzvf env.tgz
       - name: env up
         shell: bash


### PR DESCRIPTION
Tyk-ci fetch mechanism needs to be fixed in order to fetch the .tgz built file from the tyk-ci release process instead of the entire repository contents
