### PR TITLE
TT-12072 Configure Splunk client to use proxy from environment

### DIFF
--- a/pumps/splunk.go
+++ b/pumps/splunk.go
@@ -302,7 +302,7 @@ func NewSplunkClient(token string, collectorURL string, skipVerify bool, certFil
 		}
 		tlsConfig = &tls.Config{Certificates: []tls.Certificate{cert}, ServerName: serverName}
 	}
-	http.DefaultClient.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+	http.DefaultClient.Transport = &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: tlsConfig}
 	// Append the default collector API path:
 	u.Path = defaultPath
 	c = &SplunkClient{

--- a/pumps/splunk_test.go
+++ b/pumps/splunk_test.go
@@ -202,6 +202,22 @@ func Test_SplunkBackoffRetry(t *testing.T) {
 	})
 }
 
+func TestSplunkProxy(t *testing.T) {
+	client, err := NewSplunkClient(testToken, testEndpointURL, true, "", "", "")
+	if err != nil {
+		t.Error("Error initializing Splunk client:", err.Error())
+		return
+	}
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Error("Transport type assertion failed")
+		return
+	}
+
+	assert.True(t, transport.Proxy != nil, "Splunk transport proxy should not be nil")
+}
+
 func Test_SplunkWriteData(t *testing.T) {
 	handler := &testHandler{test: t, batched: false}
 	server := httptest.NewServer(handler)


### PR DESCRIPTION
This PR resolves issue #816 by configuring the Splunk client to use proxy settings from the environment.

## Description

I set the proxy to `http.ProxyFromEnvironment` when initializing the Splunk client transport.

## Related Issue

- #816 

## Motivation and Context

Support for HTTP_PROXY environment variables is required when running Tyk Pump in restricted environments that require all HTTP traffic to go through a proxy.

## How This Has Been Tested

I included a unit test that verifies the proxy is not nil after initializing a Splunk client. I attempted to fully test the functionality by setting the HTTP_PROXY environment variable, but this caused other Splunk tests to fail. Since this fix leverages existing functionality from `http.ProxyFromEnvironment`, I don't think it's necessary to have end-to-end test coverage. 

Technically one could set Proxy to something other than ProxyFromEnvironment and the test would pass so this is a gap. It would be ideal to verify the function pointers are the same, but I couldn't get it to work. I'm open to feedback on how to better handle this test.

## Screenshots (if appropriate)

Not applicable.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [X] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [X] I have updated the documentation accordingly.
- [X] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] Check your code additions will not fail linting checks:
  - [X] `go fmt -s`
  - [X] `go vet`
