### PR TITLE
Merging to release-1.10: Removing FIPS from NFPMS (#833)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+build-fips:
+	GOEXPERIMENT=boringcrypto go build -tags=boringcrypto
+
+clean:
+	rm -f tyk-pump
+
+run-fips: build-fips
+	./tyk-pump
+
+validate-fips: build-fips
+	go tool nm tyk-pump | grep -i boring
+
+.PHONY: build-fips clean run-fips validate-fips

--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -5,8 +5,8 @@ ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY tyk-pump*${TARGETARCH}.deb /tyk-pump.deb
-RUN dpkg -i /tyk-pump.deb && rm /tyk-pump.deb
+COPY *${TARGETARCH}.deb /
+RUN dpkg -i /tyk-pump*${TARGETARCH}.deb && rm /*.deb
 
 FROM gcr.io/distroless/static-debian12:nonroot
 

--- a/ci/goreleaser/goreleaser.yml
+++ b/ci/goreleaser/goreleaser.yml
@@ -19,23 +19,6 @@ builds:
       - s390x
     binary: tyk-pump
 
-  - id: fips-linux
-    flags:
-      - -tags=boringcrypto
-    ldflags:
-      - -X github.com/TykTechnologies/tyk-pump/pumps.Version={{.Version}}
-      - -X github.com/TykTechnologies/tyk-pump/pumps.Commit={{.FullCommit}}
-      - -X github.com/TykTechnologies/tyk-pump/pumps.BuildDate={{.Date}}
-      - -X github.com/TykTechnologies/tyk-pump/pumps.BuiltBy=goreleaser
-    env:
-      - GOEXPERIMENT=boringcrypto
-    goos:
-      - linux
-    goarch:
-      - amd64
-      - arm64
-    binary: tyk-pump-fips
-
 dockers:
   # Build tykio/tyk-pump-docker-pub, docker.tyk.io/tyk-pump/tyk-pump (amd64)
   - ids:
@@ -43,27 +26,6 @@ dockers:
     image_templates:
       - "tykio/tyk-pump-docker-pub:{{.Tag}}-amd64"
       - "docker.tyk.io/tyk-pump/tyk-pump:{{.Tag}}-amd64"
-    build_flag_templates:
-      - "--build-arg=PORTS=80"
-      - "--platform=linux/amd64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    use: buildx
-    goarch: amd64
-    goos: linux
-    dockerfile: ci/Dockerfile.std
-    extra_files:
-      - "ci/install/"
-      - "README.md"
-      - "LICENSE.md"
-      - "pump.example.conf"
-  - ids:
-      - std
-    image_templates:
-      - "tykio/tyk-pump-docker-pub:{{.Tag}}-fips-amd64"
-      - "docker.tyk.io/tyk-pump/tyk-pump:{{.Tag}}-fips-amd64"
     build_flag_templates:
       - "--build-arg=PORTS=80"
       - "--platform=linux/amd64"
@@ -102,53 +64,24 @@ dockers:
       - "README.md"
       - "LICENSE.md"
       - "pump.example.conf"
-  - ids:
-      - std
-    image_templates:
-      - "tykio/tyk-pump-docker-pub:{{.Tag}}-fips-arm64"
-      - "docker.tyk.io/tyk-pump/tyk-pump:{{.Tag}}-fips-arm64"
-    build_flag_templates:
-      - "--build-arg=PORTS=80"
-      - "--platform=linux/arm64"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-    use: buildx
-    goarch: arm64
-    goos: linux
-    dockerfile: ci/Dockerfile.std
-    extra_files:
-      - "ci/install/"
-      - "README.md"
-      - "LICENSE.md"
-      - "pump.example.conf"
 
 docker_manifests:
   - name_template: tykio/tyk-pump-docker-pub:{{ .Tag }}
     image_templates:
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-amd64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-amd64
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-arm64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-arm64
   - name_template: tykio/tyk-pump-docker-pub:v{{ .Major }}.{{ .Minor }}{{.Prerelease}}
     image_templates:
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-amd64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-amd64
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-arm64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-arm64
   - name_template: tykio/tyk-pump-docker-pub:v{{ .Major }}{{.Prerelease}}
     image_templates:
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-amd64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-amd64
       - tykio/tyk-pump-docker-pub:{{ .Tag }}-arm64
-      - tykio/tyk-pump-docker-pub:{{ .Tag }}-fips-arm64
   - name_template: docker.tyk.io/tyk-pump/tyk-pump:{{ .Tag }}
     image_templates:
       - docker.tyk.io/tyk-pump/tyk-pump:{{ .Tag }}-amd64
-      - docker.tyk.io/tyk-pump/tyk-pump:{{ .Tag }}-fips-amd64
       - docker.tyk.io/tyk-pump/tyk-pump:{{ .Tag }}-arm64
-      - docker.tyk.io/tyk-pump/tyk-pump:{{ .Tag }}-fips-arm64
 
 nfpms:
   - id: std
@@ -191,47 +124,6 @@ nfpms:
       signature:
         key_file: tyk.io.signing.key
         type: origin
-
-  - id: fips
-    vendor: "Tyk Technologies Ltd"
-    homepage: "https://tyk.io"
-    maintainer: "Tyk <info@tyk.io>"
-    description: Tyk Analytics Pump to move analytics data from Redis to any supported backend (multiple backends can be written to at once).
-    package_name: tyk-pump-fips
-    file_name_template: "{{ .ConventionalFileName }}"
-    builds:
-      - fips-linux
-    formats:
-      - deb
-      - rpm
-    contents:
-      - src: "README.md"
-        dst: "/opt/share/docs/tyk-pump-fips/README.md"
-      - src: "ci/install/*"
-        dst: "/opt/tyk-pump-fips/install"
-      - src: ci/install/inits/systemd/system/tyk-pump.service
-        dst: "/lib/systemd/system/tyk-pump.service"
-      - src: ci/install/inits/sysv/init.d/tyk-pump
-        dst: "/etc/init.d/tyk-pump"
-      - src: "LICENSE.md"
-        dst: "/opt/share/docs/tyk-pump-fips/LICENSE.md"
-      - src: pump.example.conf
-        dst: "/opt/tyk-pump/pump.conf"
-    scripts:
-      preinstall: "ci/install/before_install.sh"
-      postinstall: "ci/install/post_install.sh"
-      postremove: "ci/install/post_remove.sh"
-    bindir: "/opt/tyk-pump/fips"
-    rpm:
-      scripts:
-        posttrans: ci/install/post_trans.sh
-      signature:
-        key_file: tyk.io.signing.key
-    deb:
-      signature:
-        key_file: tyk.io.signing.key
-        type: origin
-
 publishers:
   - name: tyk-pump-unstable
     env:


### PR DESCRIPTION
Removing FIPS from NFPMS (#833)

* chore: Update Dockerfile.std for fips-linux build

* feat: Update binary name for fips-linux build to tyk-pump-fips

* feat: Update binary name for fips-linux build to tyk-pump-fips

* Update binary name for fips-linux build to tyk-pump-fips

* Update Dockerfile.std and build configuration for fips-linux build

* Update Dockerfile.std and build configuration for fips-linux build

* Update Dockerfile.std and build configuration for fips-linux build

* removing duplicated jobs

* Update Dockerfile.std and build configuration for fips-linux build

* Update Dockerfile.distroless for standard package installation

* Update Dockerfile.distroless for standard package installation

* Update Dockerfile.distroless for standard package installation

* Update Dockerfile.distroless for standard package installation

* Update binary name for fips-linux build to tyk-pump-fips

* Update Dockerfile.distroless for standard package installation

* adding dockerfile to locally build a pips compliant option

* fixing CI

* uncommenting fips related

* removing unused dockerfile

* restoring release.yml

* removing fips from nfpms

* add fips imgs into os dockerfiles

* creating Makefile to build and validate fips

* removing BINARY_NAME from makefile

---------

Co-authored-by: sredny buitrago <sredny.buitrago@gmail.com>