### PR TITLE
Add taskfile to generate markdown docs locally, lint godocs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,17 @@
+---
+version: "3"
+
+vars:
+  title: "# Tyk Pump"
+  root: TykPumpConfiguration
+
+tasks:
+  docs:
+    desc: "Generate markdown with schema-gen"
+    cmds:
+      - schema-gen extract -o - | schema-gen markdown -i - -o - --root {{.root}} --title "{{.title}}"
+
+  lint:
+    desc: "Lint godocs with schema-gen"
+    cmds:
+      - schema-gen extract -o - | schema-gen lint -i -


### PR DESCRIPTION
Added taskfile:

- `task docs`, invokes schema-gen to generate markdown
- `task lint`, invokes the godoc linter reporting issues in config pkg godoc

