### PR TITLE
Fix can not use custom buckets in Prometheus histogram type

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -334,7 +334,7 @@ func (pm *PrometheusMetric) InitVec() error {
 			prometheus.HistogramOpts{
 				Name:    pm.Name,
 				Help:    pm.Help,
-				Buckets: buckets,
+				Buckets: bkts,
 			},
 			pm.Labels,
 		)


### PR DESCRIPTION

## Description
When initailzing the HistogramVec in Prometheus, the buckets are still the default bucket. Fix it by simply change the variable.

## Related Issue
When initailzing the HistogramVec in Prometheus, the buckets are still the default bucket.


