### PR TITLE
Upgrading upload-artifact to v3

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           version: latest
           args: --out-format=checkstyle:golanglint.xml --timeout=300s --max-issues-per-linter=0 --max-same-issues=0 --new-from-rev=origin/${{ github.base_ref }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: golangcilint
           retention-days: 1
@@ -90,4 +90,3 @@ jobs:
           result_code=${PIPESTATUS[0]}
           echo "log=$(sed -ze 's/%/%25/g;s/\n/%0A/g' test.log)" >> $GITHUB_OUTPUT
           exit $result_code
-   

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM golang:1.21 as builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GOEXPERIMENT=boringcrypto go build -tags=boringcrypto -o tyk-pump .
+
+FROM debian:bookworm-slim
+
+WORKDIR /opt/tyk-pump
+
+COPY --from=builder /app/tyk-pump .
+
+COPY pump.example.conf /opt/tyk-pump/pump.conf
+
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/tyk-pump/tyk-pump"]
+CMD ["--conf=/opt/tyk-pump/pump.conf"]


### PR DESCRIPTION
CIs are failing because version 2 was deprecated.