### PR TITLE
bug/TT-12184

### DIFF
--- a/pumps/stdout_test.go
+++ b/pumps/stdout_test.go
@@ -1,0 +1,68 @@
+package pumps
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/sirupsen/logrus"
+)
+
+// Previous implementation was canceling the writes if the context was cancelled.
+// This test ensures that the pump will continue to write data even if the context is cancelled.
+func TestStdOutPump_WriteData_ContextCancellation(t *testing.T) {
+    // Setup pump
+    pump := &StdOutPump{
+        conf: &StdOutConf{
+            LogFieldName: "test-analytics",
+            Format:      "json",
+        },
+    }
+
+    // Setup logger
+    logger := logrus.New()
+    logger.SetLevel(logrus.DebugLevel)
+    pump.log = logger.WithField("prefix", "test")
+
+	// Create many records to test with
+    data := make([]interface{}, 100)
+    for i := range data {
+        data[i] = analytics.AnalyticsRecord{
+            Path:   fmt.Sprintf("/test/%d", i),
+            Method: "GET",
+        }
+    }
+
+    // Create an already cancelled context 
+	// && cancel immediately
+    ctx, cancel := context.WithCancel(context.Background())
+    cancel() 
+
+
+	// Capture logger output
+	var buf bytes.Buffer
+	pump.log.Logger.SetOutput(&buf)
+	oldOut := pump.log.Logger.Out
+	defer pump.log.Logger.SetOutput(oldOut)  // restore original output when done
+
+    err := pump.WriteData(ctx, data)
+
+	output := buf.String()
+
+    if err != nil {
+        t.Errorf("Expected no error, wanted the Pump to finish purging despite context cancellation, got %v", err)
+    }
+
+	// Verify the output contains the expected message
+	attemptMsg := "Attempting to write 100 records"
+	if !strings.Contains(output, attemptMsg) {
+		t.Errorf("Expected output does not contain '%s'", attemptMsg)
+	}
+	purgeMsg := "Purged 100 records..."
+	if !strings.Contains(output, purgeMsg) {
+		t.Errorf("Expected output does not contain '%s'", purgeMsg)
+	}
+}


### PR DESCRIPTION
Changed the implementation of the `stdout` pump to finish writes regardless of previous context cancellations.

## Description
Changed the implementation of the `stdout` pump to finish writes regardless of previous context cancellations.

## Motivation and Context
In few other pumps I've investigated (Splunk, Hybrid), the Pumps do not conditionally write based on context cancellations.  The STDOUT is the only Pump that does.  I've changed this behaviour so it now finishes all writes without being interrupted.

## How This Has Been Tested
A unit test has been written that will force a cancellation context before the writes are started.  Then, it will check to make sure all teh writes took place.  With the original implementation of `stdout`, this test failed.  With the new implementation, this test passes.

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [ ] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [ ] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
