### PR TITLE
Merging to release-1.11: TT-12780 prevent sql pump to panic when sharding enabled and skip api id is set (#860)

### DIFF
--- a/pumps/sql.go
+++ b/pumps/sql.go
@@ -212,7 +212,7 @@ func (c *SQLPump) WriteData(ctx context.Context, data []interface{}) error {
 	endIndex := dataLen
 	// We iterate dataLen +1 times since we're writing the data after the date change on sharding_table:true
 	for i := 0; i <= dataLen; i++ {
-		if c.SQLConf.TableSharding {
+		if c.SQLConf.TableSharding && startIndex < len(typedData) {
 			recDate := typedData[startIndex].TimeStamp.Format("20060102")
 			var nextRecDate string
 			// if we're on i == dataLen iteration, it means that we're out of index range. We're going to use the last record date.

--- a/pumps/sql_test.go
+++ b/pumps/sql_test.go
@@ -146,6 +146,26 @@ func TestSQLWriteDataSharded(t *testing.T) {
 			assert.Equal(t, data.RowsLen, len(dbRecords))
 		})
 	}
+
+	t.Run("empty_keys", func(t *testing.T) {
+		emptyKeys := make([]interface{}, 0)
+		errWrite := pmp.WriteData(context.Background(), emptyKeys)
+		if errWrite != nil {
+			t.Fatal("SQL Pump couldn't write records with err:", errWrite)
+		}
+
+		// Check if any table has been created for the empty input case
+		tables := []string{
+			analytics.SQLTable + "_" + now.Format("20060102"),
+			analytics.SQLTable + "_" + nowPlus1.Format("20060102"),
+			analytics.SQLTable + "_" + nowPlus2.Format("20060102"),
+		}
+		for _, table := range tables {
+			t.Run("checking_"+table, func(t *testing.T) {
+				assert.Equal(t, false, pmp.db.Migrator().HasTable(table)) // No table should exist
+			})
+		}
+	})
 }
 
 func TestSQLWriteUptimeData(t *testing.T) {


### PR DESCRIPTION
TT-12780 prevent sql pump to panic when sharding enabled and skip api id is set (#860)

* prevent sql pump to panic when sharding enabled and skip api id is set

* revert doc change

---------

Co-authored-by: sredny buitrago <sredny@srednys-MacBook-Pro.local>