### PR TITLE
[TT-13937] Adding key obfuscation to the Prometheus pump

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -378,7 +378,7 @@ func (pm *PrometheusMetric) ensureLabels() {
 func (pm *PrometheusMetric) GetLabelsValues(decoded analytics.AnalyticsRecord) []string {
 	values := []string{}
 	// If API Key obfuscation is enabled, we only show the last <ObfuscateAPIKeysLength> characters of the API Key
-	apiKey := obfuscateAPIKey(decoded.APIKey, pm.ObfuscateAPIKeys, pm.ObfuscateAPIKeysLength)
+	apiKey := pm.obfuscateAPIKey(decoded.APIKey)
 	mapping := map[string]interface{}{
 		"host":          decoded.Host,
 		"method":        decoded.Method,
@@ -408,19 +408,15 @@ func (pm *PrometheusMetric) GetLabelsValues(decoded analytics.AnalyticsRecord) [
 	return values
 }
 
-func obfuscateAPIKey(apiKey string, obfuscate bool, length int) string {
-	if !obfuscate {
+func (pm *PrometheusMetric) obfuscateAPIKey(apiKey string) string {
+	if !pm.ObfuscateAPIKeys {
 		return apiKey
 	}
-	if length == 0 {
-		length = 4
-	}
 
-	if len(apiKey) <= length {
-		return "****"
+	if len(apiKey) > 4 {
+		return "****" + apiKey[len(apiKey)-4:]
 	}
-
-	return "****" + apiKey[len(apiKey)-length:]
+	return "--"
 }
 
 // Inc is going to fill counterMap and histogramMap with the data from record.

--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -291,18 +291,17 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 		{
 			testName: "empty API key with obfuscation enabled",
 			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       true,
-				ObfuscateAPIKeysLength: 4,
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: true,
 			},
 			record: analytics.AnalyticsRecord{
 				APIID:        "api_1",
 				ResponseCode: 200,
 				APIKey:       "",
 			},
-			expectedLabels: []string{"200", "api_1", "****"},
+			expectedLabels: []string{"200", "api_1", "--"},
 		},
 		{
 			testName: "tree valid labels",
@@ -353,11 +352,10 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 		{
 			testName: "obfuscated API key - showing last 4 chars",
 			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       true,
-				ObfuscateAPIKeysLength: 4,
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: true,
 			},
 			record: analytics.AnalyticsRecord{
 				APIID:        "api_1",
@@ -367,61 +365,42 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 			expectedLabels: []string{"200", "api_1", "****mnop"},
 		},
 		{
-			testName: "obfuscated API key - short key length",
+			testName: "obfuscated API key - short key (4 chars)",
 			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       true,
-				ObfuscateAPIKeysLength: 6,
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: true,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abcd",
+			},
+			expectedLabels: []string{"200", "api_1", "--"},
+		},
+		{
+			testName: "obfuscated API key - very short key (3 chars)",
+			customMetric: PrometheusMetric{
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: true,
 			},
 			record: analytics.AnalyticsRecord{
 				APIID:        "api_1",
 				ResponseCode: 200,
 				APIKey:       "abc",
 			},
-			expectedLabels: []string{"200", "api_1", "****"},
-		},
-		{
-			testName: "obfuscated API key - default length (zero length should default to 4)",
-			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       true,
-				ObfuscateAPIKeysLength: 0,
-			},
-			record: analytics.AnalyticsRecord{
-				APIID:        "api_1",
-				ResponseCode: 200,
-				APIKey:       "abcdefghijklmnop",
-			},
-			expectedLabels: []string{"200", "api_1", "****mnop"},
-		},
-		{
-			testName: "obfuscated API key - default length with short key",
-			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       true,
-				ObfuscateAPIKeysLength: 0,
-			},
-			record: analytics.AnalyticsRecord{
-				APIID:        "api_1",
-				ResponseCode: 200,
-				APIKey:       "abc",
-			},
-			expectedLabels: []string{"200", "api_1", "****"},
+			expectedLabels: []string{"200", "api_1", "--"},
 		},
 		{
 			testName: "obfuscation disabled",
 			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       false,
-				ObfuscateAPIKeysLength: 4,
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: false,
 			},
 			record: analytics.AnalyticsRecord{
 				APIID:        "api_1",
@@ -431,20 +410,19 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 			expectedLabels: []string{"200", "api_1", "abcdefghijklmnop"},
 		},
 		{
-			testName: "obfuscation disabled with zero length",
+			testName: "obfuscation disabled with short key",
 			customMetric: PrometheusMetric{
-				Name:                   "testCounterMetric",
-				MetricType:             counterType,
-				Labels:                 []string{"code", "api", "key"},
-				ObfuscateAPIKeys:       false,
-				ObfuscateAPIKeysLength: 0,
+				Name:             "testCounterMetric",
+				MetricType:       counterType,
+				Labels:           []string{"code", "api", "key"},
+				ObfuscateAPIKeys: false,
 			},
 			record: analytics.AnalyticsRecord{
 				APIID:        "api_1",
 				ResponseCode: 200,
-				APIKey:       "abcdefghijklmnop",
+				APIKey:       "abc",
 			},
-			expectedLabels: []string{"200", "api_1", "abcdefghijklmnop"},
+			expectedLabels: []string{"200", "api_1", "abc"},
 		},
 	}
 

--- a/pumps/prometheus_test.go
+++ b/pumps/prometheus_test.go
@@ -289,6 +289,22 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 		expectedLabels []string
 	}{
 		{
+			testName: "empty API key with obfuscation enabled",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       true,
+				ObfuscateAPIKeysLength: 4,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "",
+			},
+			expectedLabels: []string{"200", "api_1", "****"},
+		},
+		{
 			testName: "tree valid labels",
 			customMetric: PrometheusMetric{
 				Name:       "testCounterMetric",
@@ -333,6 +349,102 @@ func TestPrometheusGetLabelsValues(t *testing.T) {
 				APIKey:       "apikey",
 			},
 			expectedLabels: []string{"200", "api_1", "apikey"},
+		},
+		{
+			testName: "obfuscated API key - showing last 4 chars",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       true,
+				ObfuscateAPIKeysLength: 4,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abcdefghijklmnop",
+			},
+			expectedLabels: []string{"200", "api_1", "****mnop"},
+		},
+		{
+			testName: "obfuscated API key - short key length",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       true,
+				ObfuscateAPIKeysLength: 6,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abc",
+			},
+			expectedLabels: []string{"200", "api_1", "****"},
+		},
+		{
+			testName: "obfuscated API key - default length (zero length should default to 4)",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       true,
+				ObfuscateAPIKeysLength: 0,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abcdefghijklmnop",
+			},
+			expectedLabels: []string{"200", "api_1", "****mnop"},
+		},
+		{
+			testName: "obfuscated API key - default length with short key",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       true,
+				ObfuscateAPIKeysLength: 0,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abc",
+			},
+			expectedLabels: []string{"200", "api_1", "****"},
+		},
+		{
+			testName: "obfuscation disabled",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       false,
+				ObfuscateAPIKeysLength: 4,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abcdefghijklmnop",
+			},
+			expectedLabels: []string{"200", "api_1", "abcdefghijklmnop"},
+		},
+		{
+			testName: "obfuscation disabled with zero length",
+			customMetric: PrometheusMetric{
+				Name:                   "testCounterMetric",
+				MetricType:             counterType,
+				Labels:                 []string{"code", "api", "key"},
+				ObfuscateAPIKeys:       false,
+				ObfuscateAPIKeysLength: 0,
+			},
+			record: analytics.AnalyticsRecord{
+				APIID:        "api_1",
+				ResponseCode: 200,
+				APIKey:       "abcdefghijklmnop",
+			},
+			expectedLabels: []string{"200", "api_1", "abcdefghijklmnop"},
 		},
 	}
 


### PR DESCRIPTION
Duplicate of #865 
Parameters for api_key obfuscation are added to the Prometheus pump.

## Description
- Adding 2 parameters in the Prometheus custom metrics in which the user can select if they want to obfuscate the API key and if yes, how many characters they want to show in it.
- Adding a validation in the `GetLabelsValues` function of the promethus pump that will validate if the variables are set and it will modify the api_key and the key parameters.

## Related Issue
https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/42?selectedIssue=TT-13937

## Motivation and Context
- In my case the /metrics endpoint that is exposed by the container can be accessed by other user. We need to obfuscate the key so that we can reduce the chance of a key being leaked.

## How This Has Been Tested
- Tested on a remote env using applications that are making constant requests to the gateways. In this env, we are using MongoDB and Redis.

## Screenshots (if appropriate)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
<!-- If you're unsure about any of these, don't hesitate to ask; we're here to help! -->
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). If pulling from your own
      fork, don't request your `master`!
- [x] Make sure you are making a pull request against the **`master` branch** (left side). Also, you should start
      *your branch* off *our latest `master`*.
- [x] My change requires a change to the documentation.
  - [ ] If you've changed APIs, describe what needs to be updated in the documentation.
- [x] I have updated the documentation accordingly.
- [ ] Modules and vendor dependencies have been updated; run `go mod tidy && go mod vendor`
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] Check your code additions will not fail linting checks:
  - [ ] `go fmt -s`
  - [ ] `go vet`
