### PR TITLE
Fix syslog pump log fragmentation issue

### DIFF
--- a/pumps/syslog.go
+++ b/pumps/syslog.go
@@ -2,6 +2,7 @@ package pumps
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/syslog"
 
@@ -167,8 +168,15 @@ func (s *SyslogPump) WriteData(ctx context.Context, data []interface{}) error {
 				"user_agent":      decoded.UserAgent,
 			}
 
-			// Print to Syslog
-			_, _ = fmt.Fprintf(s.writer, "%s", message)
+			// Serialize to JSON to prevent log fragmentation
+			jsonData, err := json.Marshal(message)
+			if err != nil {
+				s.log.Error("Failed to marshal message to JSON: ", err)
+				continue
+			}
+
+			// Print to Syslog as single-line JSON
+			_, _ = fmt.Fprintf(s.writer, "%s", string(jsonData))
 		}
 	}
 	s.log.Info("Purged ", len(data), " records...")


### PR DESCRIPTION
## Summary
- Fix log fragmentation in syslog pump when raw_request/raw_response contain newlines
- Serialize analytics data to JSON before writing to syslog writer
- Ensures entire record is treated as single atomic message

## Problem
The syslog pump was causing log fragmentation when `raw_request` and `raw_response` fields contained newline characters. The `fmt.Fprintf` call on line 171 was not properly escaping these characters, causing the syslog daemon to interpret each newline as a separate log entry, breaking single analytics records into multiple fragmented log entries.

## Solution
- Added `encoding/json` import
- Marshal the message map to JSON before writing to syslog
- Added proper error handling for JSON marshaling failures
- This ensures the raw request/response data is properly escaped within the JSON structure

## Test plan
- [x] Verify the code compiles successfully
- [ ] Test with syslog pump configuration that includes raw request/response data containing newlines
- [ ] Verify that analytics records appear as single log entries in syslog output

🤖 Generated with [Claude Code](https://claude.ai/code)