### PR TITLE
Merging to release-1.12.1: [TT-15532] Alternative backward-compatible fix for syslog pump log fragmentation (#886)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ pumps/chunk.go
 migrate.js
 utils/release_rc.sh
 .terraform**
+.claude/settings.local.json

--- a/pumps/syslog.go
+++ b/pumps/syslog.go
@@ -2,9 +2,9 @@ package pumps
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/syslog"
+	"strings"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -149,6 +149,7 @@ func (s *SyslogPump) WriteData(ctx context.Context, data []interface{}) error {
 		default:
 			// Decode the raw analytics into Form
 			decoded := v.(analytics.AnalyticsRecord)
+<<<<<<< HEAD
 			
 			if s.syslogConf.SyslogFragmentation {
 				// New behavior: Serialize to JSON to prevent log fragmentation
@@ -206,6 +207,38 @@ func (s *SyslogPump) WriteData(ctx context.Context, data []interface{}) error {
 					decoded.ContentLength,
 					decoded.UserAgent)
 			}
+=======
+
+			// Escape newlines in raw_request and raw_response to prevent log fragmentation
+			// while maintaining the original map format for backward compatibility
+			escapedRawRequest := strings.ReplaceAll(decoded.RawRequest, "\n", "\\n")
+			escapedRawResponse := strings.ReplaceAll(decoded.RawResponse, "\n", "\\n")
+
+			message := Json{
+				"timestamp":       decoded.TimeStamp,
+				"method":          decoded.Method,
+				"path":            decoded.Path,
+				"raw_path":        decoded.RawPath,
+				"response_code":   decoded.ResponseCode,
+				"alias":           decoded.Alias,
+				"api_key":         decoded.APIKey,
+				"api_version":     decoded.APIVersion,
+				"api_name":        decoded.APIName,
+				"api_id":          decoded.APIID,
+				"org_id":          decoded.OrgID,
+				"oauth_id":        decoded.OauthID,
+				"raw_request":     escapedRawRequest,
+				"request_time_ms": decoded.RequestTime,
+				"raw_response":    escapedRawResponse,
+				"ip_address":      decoded.IPAddress,
+				"host":            decoded.Host,
+				"content_length":  decoded.ContentLength,
+				"user_agent":      decoded.UserAgent,
+			}
+
+			// Print to Syslog using original map format (maintains backward compatibility)
+			_, _ = fmt.Fprintf(s.writer, "%s", message)
+>>>>>>> 0596e82... [TT-15532] Alternative backward-compatible fix for syslog pump log fragmentation (#886)
 		}
 	}
 	s.log.Info("Purged ", len(data), " records...")

--- a/pumps/syslog_test.go
+++ b/pumps/syslog_test.go
@@ -2,6 +2,7 @@ package pumps
 
 import (
 	"context"
+<<<<<<< HEAD
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,4 +86,315 @@ func TestSyslogPump_SetAndGetFilters(t *testing.T) {
 	
 	pump.SetFilters(filters)
 	assert.Equal(t, filters, pump.GetFilters())
+=======
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockSyslogServer creates a simple UDP syslog server for testing
+func mockSyslogServer(t *testing.T) (string, chan string) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	conn, err := net.ListenUDP("udp", addr)
+	require.NoError(t, err)
+
+	messages := make(chan string, 100)
+
+	go func() {
+		defer conn.Close()
+		buffer := make([]byte, 1024)
+		for {
+			n, _, err := conn.ReadFromUDP(buffer)
+			if err != nil {
+				return
+			}
+			messages <- string(buffer[:n])
+		}
+	}()
+
+	return conn.LocalAddr().String(), messages
+}
+
+// Helper function to create a SyslogPump with test configuration
+func createTestSyslogPump(addr string) *SyslogPump {
+	pump := &SyslogPump{
+		syslogConf: &SyslogConf{
+			Transport:   "udp",
+			NetworkAddr: addr,
+			LogLevel:    6, // Info level
+			Tag:         "test",
+		},
+		CommonPumpConfig: CommonPumpConfig{
+			log: log.WithField("prefix", "test"),
+		},
+	}
+
+	// Initialize the writer
+	pump.initWriter()
+	return pump
+}
+
+func TestSyslogPump_WriteData(t *testing.T) {
+	tests := []struct {
+		name     string
+		data     []interface{}
+		wantLogs int // expected number of log entries
+	}{
+		{
+			name: "Single valid record",
+			data: []interface{}{
+				analytics.AnalyticsRecord{
+					Method:       "GET",
+					Path:         "/api/test",
+					ResponseCode: 200,
+					TimeStamp:    time.Now(),
+				},
+			},
+			wantLogs: 1,
+		},
+		{
+			name: "Multiple valid records",
+			data: []interface{}{
+				analytics.AnalyticsRecord{
+					Method:       "GET",
+					Path:         "/api/test1",
+					ResponseCode: 200,
+					TimeStamp:    time.Now(),
+				},
+				analytics.AnalyticsRecord{
+					Method:       "POST",
+					Path:         "/api/test2",
+					ResponseCode: 201,
+					TimeStamp:    time.Now(),
+				},
+			},
+			wantLogs: 2,
+		},
+		{
+			name:     "Empty data slice",
+			data:     []interface{}{},
+			wantLogs: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock syslog server
+			addr, messages := mockSyslogServer(t)
+
+			// Create syslog pump with test configuration
+			s := createTestSyslogPump(addr)
+
+			// Call WriteData
+			err := s.WriteData(context.Background(), tt.data)
+			assert.NoError(t, err)
+
+			if tt.wantLogs == 0 {
+				// Give a small amount of time for any potential messages
+				select {
+				case <-messages:
+					t.Error("Expected no messages but received one")
+				case <-time.After(100 * time.Millisecond):
+					// Good, no messages received
+				}
+				return
+			}
+
+			// Collect messages
+			var receivedMessages []string
+			timeout := time.After(2 * time.Second)
+			for len(receivedMessages) < tt.wantLogs {
+				select {
+				case msg := <-messages:
+					receivedMessages = append(receivedMessages, msg)
+				case <-timeout:
+					break
+				}
+			}
+
+			assert.Equal(t, tt.wantLogs, len(receivedMessages), "Expected %d log entries, got %d", tt.wantLogs, len(receivedMessages))
+
+			// Verify each message contains the original map format
+			for i, msg := range receivedMessages {
+				// Syslog messages have a header, extract the map part
+				// Look for the map starting with 'map['
+				mapStart := strings.Index(msg, "map[")
+				require.True(t, mapStart >= 0, "Message should contain map format: %s", msg)
+				mapPart := strings.TrimSpace(msg[mapStart:])
+
+				// Verify it's the expected map format
+				assert.True(t, strings.HasPrefix(mapPart, "map["), "Log entry %d should start with 'map[': %s", i, mapPart)
+				assert.True(t, strings.HasSuffix(mapPart, "]"), "Log entry %d should end with ']': %s", i, mapPart)
+			}
+		})
+	}
+}
+
+func TestSyslogPump_WriteData_WithMultilineHTTP(t *testing.T) {
+	// Test data with realistic multiline HTTP requests/responses that would cause fragmentation
+	record := analytics.AnalyticsRecord{
+		Method:       "POST",
+		Path:         "/api/users",
+		ResponseCode: 201,
+		TimeStamp:    time.Now(),
+		// Real HTTP request with headers and body
+		RawRequest: `POST /api/users HTTP/1.1
+Host: api.example.com
+User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36
+Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+Content-Length: 67
+
+{
+  "name": "John Doe",
+  "email": "john@example.com",
+  "age": 30
+}`,
+		// Real HTTP response with headers and body
+		RawResponse: `HTTP/1.1 201 Created
+Date: Wed, 15 Aug 2024 10:30:00 GMT
+Content-Type: application/json
+Server: nginx/1.18.0
+Content-Length: 156
+
+{
+  "id": 12345,
+  "name": "John Doe",
+  "email": "john@example.com",
+  "age": 30,
+  "created_at": "2024-08-15T10:30:00Z"
+}`,
+		UserAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+	}
+
+	// Create mock syslog server
+	addr, messages := mockSyslogServer(t)
+
+	// Create syslog pump with test configuration
+	s := createTestSyslogPump(addr)
+
+	err := s.WriteData(context.Background(), []interface{}{record})
+	assert.NoError(t, err)
+
+	// Wait for message
+	select {
+	case msg := <-messages:
+		// Extract map from syslog message
+		// Look for the map starting with 'map['
+		mapStart := strings.Index(msg, "map[")
+		require.True(t, mapStart >= 0, "Message should contain map format: %s", msg)
+		mapPart := strings.TrimSpace(msg[mapStart:])
+
+		// Verify the syslog message itself is a single line (no fragmentation)
+		lines := strings.Split(msg, "\n")
+		nonEmptyLines := []string{}
+		for _, line := range lines {
+			if strings.TrimSpace(line) != "" {
+				nonEmptyLines = append(nonEmptyLines, line)
+			}
+		}
+		assert.Equal(t, 1, len(nonEmptyLines), "Syslog message should be a single line, got %d lines", len(nonEmptyLines))
+
+		// Verify it's the expected map format
+		assert.True(t, strings.HasPrefix(mapPart, "map["), "Should be map format: %s", mapPart)
+		// Note: May be truncated due to UDP packet size limits, so don't require ending with "]"
+
+		// Verify newlines are properly escaped (should appear as \n not actual newlines)
+		assert.Contains(t, mapPart, "\\n", "Newlines should be escaped in map output")
+
+		// The key test: ensure the syslog message itself doesn't contain raw newlines that would cause fragmentation
+		// We check this by ensuring the raw multiline content appears escaped in the single-line syslog message
+		assert.Contains(t, mapPart, "raw_request:POST /api/users HTTP/1.1\\n", "Should contain escaped newlines in raw_request")
+
+		// Verify the original multiline content is present but escaped
+		assert.Contains(t, mapPart, "raw_request:", "Should contain raw_request field")
+		assert.Contains(t, mapPart, "raw_response:", "Should contain raw_response field")
+		assert.Contains(t, mapPart, "POST /api/users HTTP/1.1", "Should contain HTTP request line")
+		assert.Contains(t, mapPart, "HTTP/1.1 201 Created", "Should contain HTTP status line")
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for syslog message")
+	}
+}
+
+func TestSyslogPump_WriteData_SpecialCharacters(t *testing.T) {
+	// Test data with special characters that could break output
+	record := analytics.AnalyticsRecord{
+		Method:       "POST",
+		Path:         "/api/test",
+		ResponseCode: 200,
+		TimeStamp:    time.Now(),
+		RawRequest:   `{"message": "Hello \"World\"", "data": "line1\nline2\ttab\rcarriage"}`,
+		RawResponse:  "Response with unicode: 测试 and emoji: 🚀",
+		UserAgent:    "Agent/1.0 (Compatible; Special chars: []{}();)",
+		APIKey:       "key_with_quotes_\"and\"_backslashes\\",
+	}
+
+	// Create mock syslog server
+	addr, messages := mockSyslogServer(t)
+
+	// Create syslog pump with test configuration
+	s := createTestSyslogPump(addr)
+
+	err := s.WriteData(context.Background(), []interface{}{record})
+	assert.NoError(t, err)
+
+	// Wait for message
+	select {
+	case msg := <-messages:
+		// Extract map from syslog message
+		mapStart := strings.Index(msg, "map[")
+		require.True(t, mapStart >= 0, "Message should contain map format: %s", msg)
+		mapPart := strings.TrimSpace(msg[mapStart:])
+
+		// Verify special characters and unicode are handled properly
+		assert.Contains(t, mapPart, "raw_request:", "Should contain raw_request field")
+		assert.Contains(t, mapPart, "raw_response:", "Should contain raw_response field")
+		assert.Contains(t, mapPart, "测试", "Should preserve unicode characters")
+		assert.Contains(t, mapPart, "🚀", "Should preserve emoji")
+
+		// Verify newlines are escaped in the raw_request field
+		assert.Contains(t, mapPart, "\\n", "Newlines should be escaped")
+
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timeout waiting for syslog message")
+	}
+}
+
+func TestSyslogPump_WriteData_ContextCancellation(t *testing.T) {
+	record := analytics.AnalyticsRecord{
+		Method:       "GET",
+		Path:         "/api/test",
+		ResponseCode: 200,
+		TimeStamp:    time.Now(),
+	}
+
+	// Create mock syslog server
+	addr, messages := mockSyslogServer(t)
+
+	// Create syslog pump with test configuration
+	s := createTestSyslogPump(addr)
+
+	// Create cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := s.WriteData(ctx, []interface{}{record})
+	assert.NoError(t, err) // Should not error, just return early
+
+	// Should not have written anything due to context cancellation
+	select {
+	case <-messages:
+		t.Error("Should not receive any messages when context is cancelled")
+	case <-time.After(100 * time.Millisecond):
+		// Good, no messages received
+	}
+>>>>>>> 0596e82... [TT-15532] Alternative backward-compatible fix for syslog pump log fragmentation (#886)
 }


### PR DESCRIPTION
[TT-15532] Alternative backward-compatible fix for syslog pump log fragmentation (#886)

* Fix syslog pump log fragmentation issue with comprehensive unit tests

- Added JSON serialization to prevent multiline HTTP data from fragmenting syslog entries
- Each analytics record is now serialized to JSON before sending to syslog
- This ensures syslog entries remain single-line, preventing fragmentation across multiple log entries
- Maintains backward compatibility as the old behavior was broken for multiline data

Added comprehensive unit tests covering:
- Basic syslog functionality with single and multiple records
- Multiline HTTP request/response handling (the original fragmentation issue)
- Special character escaping and Unicode handling
- Large data payload handling
- Field preservation verification
- Context cancellation handling
- Explicit fragmentation fix demonstration

Tests use UDP mock servers to verify syslog output format and content preservation.
All tests validate that multiline data is properly escaped in JSON and syslog entries
remain single-line to prevent fragmentation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Fix syslog pump fragmentation while maintaining full backward compatibility

- Revert go.mod/go.sum changes (testcontainers dependencies were unnecessary)
- Maintain original map[key:value ...] output format for full backward compatibility
- Escape newlines only in raw_request and raw_response fields to prevent fragmentation
- Updated tests to verify map format and escaped newlines
- Single-line syslog entries prevent log fragmentation while preserving exact original format

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Fix formatting and clean up syslog tests

- Fix gofmt formatting issues in syslog_test.go
- Remove problematic tests expecting JSON format
- Keep focused tests for backward compatibility and fragmentation fix
- All tests now expect and verify original map[...] format
- Tests verify newline escaping and single-line syslog output

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Fix final formatting issues for CI

- Fixed gofmt formatting in syslog.go and syslog_test.go
- All comprehensive scenario tests pass locally
- Ready for CI validation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

* Remove Claude settings from PR and add to gitignore

- Remove .claude/settings.local.json from git tracking
- Add .claude/settings.local.json to .gitignore
- Keep file locally but exclude from repository

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

---------

Co-authored-by: Claude <noreply@anthropic.com>

[TT-15532]: https://tyktech.atlassian.net/browse/TT-15532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ