### PR TITLE
Merging to release-1.13: [TT-13166] regression when using sql table sharding pump (#905)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	gopkg.in/vmihailenco/msgpack.v2 v2.9.1
 	gorm.io/driver/mysql v1.0.3
 	gorm.io/driver/postgres v1.2.0
-	gorm.io/gorm v1.21.16
+	gorm.io/gorm v1.30.0
 )
 
 require (
@@ -89,7 +89,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3 // indirect
 	github.com/jehiah/go-strftime v0.0.0-20151206194810-2efbe75097a5 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/jinzhu/now v1.1.2 // indirect
+	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -98,6 +98,7 @@ require (
 	github.com/lib/pq v1.10.6 // indirect
 	github.com/lintianzhi/graylogd v0.0.0-20180503131252-dc68342f04dc // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/olivere/elastic v6.2.31+incompatible // indirect
@@ -130,6 +131,7 @@ require (
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/sqlite v1.1.0 // indirect
 )
 
 //replace gorm.io/gorm => ../gorm

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030I
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/TykTechnologies/gorm v1.20.7-0.20210910090358-06148e82dc85 h1:16hcEoY9Av84ykdGGAXdVZo7kY5r00247jHlxcnLP60=
@@ -23,6 +24,7 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go v1.29.11/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
@@ -233,6 +235,8 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.2 h1:eVKgfIdy9b6zbWBMgFpfDPoAMifwSZagU9HmEU6zgiI=
 github.com/jinzhu/now v1.1.2/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
+github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
+github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -288,6 +292,9 @@ github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/mitchellh/mapstructure v1.3.1 h1:cCBH2gTD2K0OtLlv/Y5H01VQCqmlDxz30kS5Y5bqfLA=
@@ -447,6 +454,7 @@ golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -457,6 +465,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -599,6 +608,10 @@ gorm.io/driver/mysql v1.0.3 h1:+JKBYPfn1tygR1/of/Fh2T8iwuVwzt+PEJmKaXzMQXg=
 gorm.io/driver/mysql v1.0.3/go.mod h1:twGxftLBlFgNVNakL7F+P/x9oYqoymG3YYT8cAfI9oI=
 gorm.io/driver/postgres v1.2.0 h1:2k0EYyqii7sfWVM7yomw6a82Jt5wjuQUpWmD6fI9fGI=
 gorm.io/driver/postgres v1.2.0/go.mod h1:c/8rVZUl30/ZyaQtAobsLRbBTubskhCrkWZDwZe1KfI=
+gorm.io/driver/sqlite v1.1.0 h1:PVykhVHGz4/rA5ZriLQKSbY/+jh6VD9LU1ERdX/l+fU=
+gorm.io/driver/sqlite v1.1.0/go.mod h1:hm2olEcl8Tmsc6eZyxYSeznnsDaMqamBvEXLNtBg4cI=
+gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
+gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=

--- a/pumps/common.go
+++ b/pumps/common.go
@@ -1,8 +1,13 @@
 package pumps
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/sirupsen/logrus"
+	"gorm.io/gorm"
 )
 
 type CommonPumpConfig struct {
@@ -79,4 +84,98 @@ func (p *CommonPumpConfig) GetDecodedRequest() bool {
 
 func (p *CommonPumpConfig) GetDecodedResponse() bool {
 	return p.decodeResponseBase64
+}
+
+// HandleTableMigration handles the table migration logic for SQL pumps
+// It migrates either all sharded tables or just the current day's table based on configuration
+func HandleTableMigration(db *gorm.DB, conf *SQLConf, tableName string, model interface{}, log *logrus.Entry, migrateAllFunc func() error) error {
+	switch {
+	case !conf.TableSharding:
+		// Non-sharded case: migrate the main table
+		if err := db.Table(tableName).AutoMigrate(model); err != nil {
+			log.WithError(err).Error("error migrating table")
+			return err
+		}
+	case conf.MigrateShardedTables:
+		// Migrate all existing sharded tables
+		if err := migrateAllFunc(); err != nil {
+			log.WithError(err).Warn("Failed to migrate existing sharded tables")
+			// Don't fail initialization, just log the warning
+		}
+	default:
+		// Migrate current day's table to ensure it has latest schema
+		currentDayTable := tableName + "_" + time.Now().Format("20060102")
+		if err := db.Table(currentDayTable).AutoMigrate(model); err != nil {
+			log.WithField("table", currentDayTable).WithError(err).Warn("Failed to migrate current day table")
+			// Don't fail initialization, just log the warning
+		} else {
+			log.WithField("table", currentDayTable).Debug("Migrated current day table")
+		}
+	}
+	return nil
+}
+
+// MigrateAllShardedTables is a generic function that migrates all existing sharded tables
+// matching the given table prefix and model type
+func MigrateAllShardedTables(db *gorm.DB, tablePrefix, logPrefix string, model interface{}, log *logrus.Entry) error {
+	log.Info("Scanning for existing sharded " + logPrefix + " tables to migrate...")
+
+	// Get all tables in the database
+	var tables []string
+	var err error
+
+	// Use database-specific queries for better compatibility
+	switch db.Dialector.Name() {
+	case "sqlite":
+		// For SQLite, use the mock information_schema.tables table (created in tests)
+		err = db.Raw(`SELECT table_name FROM "information_schema.tables" WHERE table_schema = 'public'`).Scan(&tables).Error
+	case "mysql":
+		// For MySQL, use the database name as schema
+		err = db.Raw(`SELECT table_name FROM information_schema.tables WHERE table_schema = DATABASE()`).Scan(&tables).Error
+	case "postgres":
+		// For PostgreSQL, use 'public' schema
+		err = db.Raw(`SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`).Scan(&tables).Error
+	default:
+		// Unknown database type
+		log.WithField("dialector", db.Dialector.Name()).Error("Unsupported database type for table migration")
+		return fmt.Errorf("unsupported database type: %s", db.Dialector.Name())
+	}
+	if err != nil {
+		log.WithError(err).Warn("Failed to get list of tables, skipping migration scan")
+		return nil
+	}
+
+	// Find tables matching our sharded pattern
+	shardedTables := make([]string, 0)
+	fullTablePrefix := tablePrefix + "_"
+
+	for _, table := range tables {
+		if strings.HasPrefix(table, fullTablePrefix) {
+			// Check if it matches the date pattern (YYYYMMDD)
+			suffix := strings.TrimPrefix(table, fullTablePrefix)
+			if len(suffix) == 8 {
+				// Try to parse as date to validate format
+				if _, err := time.Parse("20060102", suffix); err == nil {
+					shardedTables = append(shardedTables, table)
+				}
+			}
+		}
+	}
+
+	log.WithField("count", len(shardedTables)).Info("Found sharded " + logPrefix + " tables to migrate")
+
+	// Migrate each sharded table
+	for _, tableName := range shardedTables {
+		log.WithField("table", tableName).Debug("Migrating sharded " + logPrefix + " table")
+
+		if err := db.Table(tableName).AutoMigrate(model); err != nil {
+			log.WithField("table", tableName).WithError(err).Warn("Failed to migrate sharded " + logPrefix + " table")
+			// Continue with other tables even if one fails
+		} else {
+			log.WithField("table", tableName).Debug("Successfully migrated sharded " + logPrefix + " table")
+		}
+	}
+
+	log.Info("Completed migration of sharded " + logPrefix + " tables")
+	return nil
 }

--- a/pumps/migration_test.go
+++ b/pumps/migration_test.go
@@ -1,0 +1,334 @@
+package pumps
+
+import (
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gorm_logger "gorm.io/gorm/logger"
+)
+
+// setupTestDB creates an in-memory SQLite database for testing
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+
+	// Open in-memory SQLite database
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: gorm_logger.Default.LogMode(gorm_logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("Failed to open SQLite database: %v", err)
+	}
+
+	// Create a mock information_schema.tables for testing (to simulate PostgreSQL/MySQL behavior)
+	// Use quoted identifier to create table with dots in the name
+	err = db.Exec(`
+		CREATE TABLE "information_schema.tables" (
+			table_name TEXT,
+			table_schema TEXT
+		)
+	`).Error
+	if err != nil {
+		t.Fatalf("Failed to create information_schema.tables: %v", err)
+	}
+
+	return db
+}
+
+// setupTestLogger creates a test logger
+func setupTestLogger(t *testing.T) *logrus.Entry {
+	t.Helper()
+	return logrus.NewEntry(logrus.New())
+}
+
+// createTestShardedTables creates test tables with sharded naming pattern
+func createTestShardedTables(t *testing.T, db *gorm.DB, tablePrefix string, model interface{}, dates []string) {
+	t.Helper()
+
+	for _, date := range dates {
+		tableName := tablePrefix + "_" + date
+		err := db.Table(tableName).AutoMigrate(model)
+		if err != nil {
+			t.Fatalf("Failed to create test table %s: %v", tableName, err)
+		}
+
+		// Register the table in information_schema.tables
+		err = db.Exec("INSERT INTO \"information_schema.tables\" (table_name, table_schema) VALUES (?, 'public')", tableName).Error
+		if err != nil {
+			t.Fatalf("Failed to register table %s in information_schema: %v", tableName, err)
+		}
+	}
+}
+
+// createTestNonShardedTables creates test tables that don't match the sharded pattern
+func createTestNonShardedTables(t *testing.T, db *gorm.DB, tablePrefix string, model interface{}) {
+	t.Helper()
+
+	nonShardedTables := []string{
+		tablePrefix + "_invalid",
+		tablePrefix + "_202401",         // wrong format
+		tablePrefix + "_20240101_extra", // too long
+		"other_table",
+		"unrelated_table_20240101",
+	}
+
+	for _, tableName := range nonShardedTables {
+		err := db.Table(tableName).AutoMigrate(model)
+		if err != nil {
+			t.Fatalf("Failed to create test table %s: %v", tableName, err)
+		}
+
+		// Register the table in information_schema.tables
+		err = db.Exec("INSERT INTO \"information_schema.tables\" (table_name, table_schema) VALUES (?, 'public')", tableName).Error
+		if err != nil {
+			t.Fatalf("Failed to register table %s in information_schema: %v", tableName, err)
+		}
+	}
+}
+
+func TestMigrateAllShardedTables(t *testing.T) {
+	t.Run("successful_migration", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "test_analytics"
+		model := &analytics.AnalyticsRecord{}
+
+		// Create test sharded tables
+		testDates := []string{"20240101", "20240102", "20240103"}
+		createTestShardedTables(t, db, tablePrefix, model, testDates)
+
+		// Create some non-sharded tables that should be ignored
+		createTestNonShardedTables(t, db, tablePrefix, model)
+
+		// Run migration
+		err := MigrateAllShardedTables(db, tablePrefix, "test", model, logger)
+
+		// Verify no error occurred
+		assert.NoError(t, err)
+
+		// Verify all sharded tables still exist and are migrated
+		for _, date := range testDates {
+			tableName := tablePrefix + "_" + date
+			assert.True(t, db.Migrator().HasTable(tableName), "Table %s should exist", tableName)
+		}
+	})
+
+	t.Run("no_sharded_tables", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "test_analytics"
+		model := &analytics.AnalyticsRecord{}
+
+		// Create only non-sharded tables
+		createTestNonShardedTables(t, db, tablePrefix, model)
+
+		// Run migration
+		err := MigrateAllShardedTables(db, tablePrefix, "test", model, logger)
+
+		// Should not error even with no sharded tables
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid_date_format_ignored", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "test_analytics"
+		model := &analytics.AnalyticsRecord{}
+
+		// Create tables with invalid date formats
+		invalidDates := []string{"invalid", "202401", "20240101_extra", "not_a_date"}
+		createTestShardedTables(t, db, tablePrefix, model, invalidDates)
+
+		// Create one valid sharded table
+		validDate := []string{"20240101"}
+		createTestShardedTables(t, db, tablePrefix, model, validDate)
+
+		// Run migration
+		err := MigrateAllShardedTables(db, tablePrefix, "test", model, logger)
+
+		// Should not error
+		assert.NoError(t, err)
+
+		// Only the valid table should be processed
+		validTableName := tablePrefix + "_20240101"
+		assert.True(t, db.Migrator().HasTable(validTableName), "Valid table should exist")
+	})
+
+	t.Run("different_table_prefixes", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		model := &analytics.AnalyticsRecord{}
+
+		// Create tables with different prefixes
+		prefixes := []string{"analytics", "aggregate", "graph"}
+		for _, prefix := range prefixes {
+			dates := []string{"20240101", "20240102"}
+			createTestShardedTables(t, db, prefix, model, dates)
+		}
+
+		// Test migration for each prefix
+		for _, prefix := range prefixes {
+			err := MigrateAllShardedTables(db, prefix, prefix, model, logger)
+			assert.NoError(t, err, "Migration should succeed for prefix %s", prefix)
+		}
+	})
+
+	t.Run("empty_database", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "test_analytics"
+		model := &analytics.AnalyticsRecord{}
+
+		// Run migration on empty database
+		err := MigrateAllShardedTables(db, tablePrefix, "test", model, logger)
+
+		// Should not error
+		assert.NoError(t, err)
+	})
+}
+
+func TestMigrateAllShardedTablesWithDifferentModels(t *testing.T) {
+	t.Run("analytics_record", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "analytics"
+		model := &analytics.AnalyticsRecord{}
+		dates := []string{"20240101", "20240102"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "analytics", model, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("aggregate_record", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "aggregate"
+		model := &analytics.SQLAnalyticsRecordAggregate{}
+		dates := []string{"20240101", "20240102"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "aggregate", model, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("graph_record", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "graph"
+		model := &analytics.GraphRecord{}
+		dates := []string{"20240101", "20240102"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "graph", model, logger)
+		assert.NoError(t, err)
+	})
+}
+
+func TestMigrateAllShardedTablesEdgeCases(t *testing.T) {
+	t.Run("single_character_prefix", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "a"
+		model := &analytics.AnalyticsRecord{}
+		dates := []string{"20240101"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "single", model, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("very_long_prefix", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "very_long_table_prefix_that_might_cause_issues"
+		model := &analytics.AnalyticsRecord{}
+		dates := []string{"20240101"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "long", model, logger)
+		assert.NoError(t, err)
+	})
+
+	t.Run("prefix_with_underscores", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "test_table_with_underscores"
+		model := &analytics.AnalyticsRecord{}
+		dates := []string{"20240101"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		err := MigrateAllShardedTables(db, tablePrefix, "underscore", model, logger)
+		assert.NoError(t, err)
+	})
+}
+
+func TestMigrateAllShardedTablesLogging(t *testing.T) {
+	t.Run("log_messages_contain_prefix", func(t *testing.T) {
+		db := setupTestDB(t)
+
+		// Create a logger that captures log messages
+		logger := logrus.New()
+		logger.SetLevel(logrus.InfoLevel)
+
+		// We can't easily capture log output in this test, but we can verify
+		// that the function runs without error and the logging doesn't cause issues
+		tablePrefix := "test_analytics"
+		model := &analytics.AnalyticsRecord{}
+		dates := []string{"20240101", "20240102"}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		logEntry := logger.WithField("test", "migration")
+		err := MigrateAllShardedTables(db, tablePrefix, "test", model, logEntry)
+		assert.NoError(t, err)
+	})
+}
+
+func TestMigrateAllShardedTablesPerformance(t *testing.T) {
+	t.Run("many_tables", func(t *testing.T) {
+		db := setupTestDB(t)
+		logger := setupTestLogger(t)
+
+		tablePrefix := "performance_test"
+		model := &analytics.AnalyticsRecord{}
+
+		// Create many sharded tables
+		dates := make([]string, 100)
+		baseDate := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		for i := 0; i < 100; i++ {
+			dates[i] = baseDate.AddDate(0, 0, i).Format("20060102")
+		}
+
+		createTestShardedTables(t, db, tablePrefix, model, dates)
+
+		// Measure migration time
+		start := time.Now()
+		err := MigrateAllShardedTables(db, tablePrefix, "performance", model, logger)
+		duration := time.Since(start)
+
+		assert.NoError(t, err)
+		assert.True(t, duration < 5*time.Second, "Migration should complete within 5 seconds for 100 tables")
+	})
+}

--- a/pumps/sql_aggregate.go
+++ b/pumps/sql_aggregate.go
@@ -123,6 +123,16 @@ func (c *SQLAggregatePump) Init(conf interface{}) error {
 
 	c.db = db
 
+	// Handle table migration
+	migrateShardedTables := func() error {
+		return MigrateAllShardedTables(c.db, analytics.AggregateSQLTable, "aggregate", &analytics.SQLAnalyticsRecordAggregate{}, c.log)
+	}
+
+	if err := HandleTableMigration(c.db, &c.SQLConf.SQLConf, analytics.AggregateSQLTable, &analytics.SQLAnalyticsRecordAggregate{}, c.log, migrateShardedTables); err != nil {
+		return err
+	}
+
+	// Handle aggregate-specific setup for non-sharded tables
 	if !c.SQLConf.TableSharding {
 		// if table doesn't exist, create it
 		if err := c.ensureTable(analytics.AggregateSQLTable); err != nil {


### PR DESCRIPTION
[TT-13166] regression when using sql table sharding pump (#905)

* TT-13166, added main functionality that allows to migrate sharded tables

* TT-13166, fixed bug that didn't allow for config overwrite

* TT-13166, made code more readable

* TT-13166, added unit tests relying on sqlite

* TT-13166, refactored sql.go to use helper functions

* TT-13166, fixed golangcilint

* TT-13166, fixed mysql pump

* TT-13166, CR feedback to skip pointer reassignment

* TT-13166, renamed variable as discussed in refinement

* TT-13166, fixed naming

[TT-13166]: https://tyktech.atlassian.net/browse/TT-13166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ