### PR TITLE
[TT-16347] Update Pump to Go 1.25

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -22,7 +22,7 @@ jobs:
         redis-version: [5]
         mongodb-version: [4.2]
         postgres-version: [15]
-        go: [1.24]
+        go: [1.25]
 
     services:
       redis:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.24]
+        go: [1.25]
     services:
       redis:
         image: redis:5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.24-bookworm
+          - 1.25-bookworm
         include:
-          - golang_cross: 1.24-bookworm
+          - golang_cross: 1.25-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -128,12 +128,12 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           mask-password: 'true'
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -148,7 +148,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -181,7 +181,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -198,7 +198,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-pump-fips
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/metadata-action@v5
         with:
           images: |
@@ -213,7 +213,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -247,7 +247,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@v6
         with:
           context: "dist"
@@ -264,7 +264,7 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-pump
       - name: save deb
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -274,7 +274,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@v4
-        if: ${{ matrix.golang_cross == '1.24-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 as builder
+FROM golang:1.25 as builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TykTechnologies/tyk-pump
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/DataDog/datadog-go v4.7.0+incompatible


### PR DESCRIPTION
## Description

This PR updates Tyk Pump from Go 1.24 to Go 1.25.

The following files have been updated:
- `go.mod`: Updated Go version directive from `1.24.6` to `1.25`
- `Dockerfile`: Updated base image from `golang:1.24` to `golang:1.25`
- `.github/workflows/ci-test.yml`: Updated go-version from `1.24` to `1.25`
- `.github/workflows/linter.yaml`: Updated go-version from `1.24` to `1.25`
- `.github/workflows/release.yml`: Updated all golang-cross references from `1.24-bookworm` to `1.25-bookworm`

## Related Issue

https://tyktech.atlassian.net/browse/TT-16347

## Motivation and Context

This update is part of our commitment to staying current with Go versions to minimize exposure to security vulnerabilities.

## How This Has Been Tested

- Verified `go mod tidy` runs successfully

## Types of changes

- [x] Refactoring or add test (improvements in base code or adds test coverage to functionality)

## Checklist

- [x] I ensured that the documentation is up to date
- [x] I explained why this PR updates go.mod in detail with reasoning why it's required
- [ ] I would like a code coverage CI quality gate exception and have explained why
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-16347" title="TT-16347" target="_blank">TT-16347</a>
</summary>

|         |    |
|---------|----|
| Status  | Open |
| Summary | Update Pump to Go 1.25 |

Generated at: 2026-02-25 18:06:38

</details>

<!---TykTechnologies/jira-linter ends here-->
