### PR TITLE
[TT-16977] fix: add jira-user-email to Jira linter workflow

### DIFF
--- a/.github/workflows/jira-pr-validator.yaml
+++ b/.github/workflows/jira-pr-validator.yaml
@@ -21,4 +21,5 @@ jobs:
         uses: TykTechnologies/jira-linter@38a9cabef56171c4e52ea698fa7be3db5fca3a49 # main
         with:
           jira-base-url: 'https://tyktech.atlassian.net'
+          jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}
           jira-api-token: ${{ secrets.JIRA_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds missing `jira-user-email` input to the Jira PR validator workflow
- The Atlassian API requires both email and token for basic auth
- Without this, all Jira ticket lookups fail with 404

## Test plan
- [ ] Verify the Jira linter check passes on a PR with a valid Jira ticket reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)