### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -119,12 +119,27 @@ jobs:
           name: golangci-report
           retention-days: 1
           path: golanglint.xml
-  sonarcloud:
+  generate-token:
     if: ${{ always() }}
     needs: [gotest, golangci]
+    runs-on: ubuntu-latest
+    outputs:
+      token: ${{ steps.app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
+  sonarcloud:
+    if: ${{ always() }}
+    needs: [gotest, golangci, generate-token]
     uses: TykTechnologies/github-actions/.github/workflows/sonarcloud.yaml@d3fa20888fa2878e877e22bb7702141217290e7c # main
     with:
       exclusions: ""
     secrets:
-      GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      GH_TOKEN: ${{ needs.generate-token.outputs.token }}
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace `secrets.ORG_GH_TOKEN` (PAT) with GitHub App token (`actions/create-github-app-token`) in `linter.yaml`
- Added a `generate-token` job to produce the app token, passed to the `sonarcloud` reusable workflow

## Test plan
- [ ] Verify linter workflow runs successfully on a test PR
- [ ] Confirm SonarCloud scan receives a valid token

🤖 Generated with [Claude Code](https://claude.com/claude-code)