### PR TITLE
[TT-17004] Fix MCP Mongo aggregate cross-API merge

### DIFF
--- a/analytics/aggregate_mcp.go
+++ b/analytics/aggregate_mcp.go
@@ -14,8 +14,17 @@ const (
 // MCPRecordAggregate holds aggregated MCP analytics grouped by API.
 // It embeds AnalyticsRecordAggregate for all standard dimensions and adds
 // MCP-specific dimension maps for method, primitive type, and primitive name.
+//
+// OwnerAPIID identifies which API this aggregate belongs to. It partitions
+// MongoDB documents per (org, timestamp, api) so per-api Names/Methods/
+// Primitives counters from one proxy don't merge with another's via the
+// upsert in MCPMongoAggregatePump. The embedded AnalyticsRecordAggregate
+// already carries an APIID map[string]*Counter for cross-API roll-ups, so
+// this is a separately named scalar to avoid a field collision.
 type MCPRecordAggregate struct {
 	AnalyticsRecordAggregate `bson:",inline"`
+
+	OwnerAPIID string `bson:"owner_apiid"`
 
 	Methods    map[string]*Counter // keyed by JSONRPCMethod
 	Primitives map[string]*Counter // keyed by PrimitiveType
@@ -91,6 +100,7 @@ func initMCPAggregateForRecord(record AnalyticsRecord, dbIdentifier string, aggr
 	agg.TimeID.Day = asTime.Day()
 	agg.TimeID.Hour = asTime.Hour()
 	agg.OrgID = record.OrgID
+	agg.OwnerAPIID = record.APIID
 	agg.LastTime = record.TimeStamp
 	agg.Total.ErrorMap = make(map[string]int)
 	return agg

--- a/pumps/mcp_mongo_aggregate.go
+++ b/pumps/mcp_mongo_aggregate.go
@@ -191,8 +191,9 @@ func (m *MCPMongoAggregatePump) DoMCPAggregatedWriting(ctx context.Context, ag *
 	}
 
 	query := model.DBM{
-		"orgid":     ag.OrgID,
-		"timestamp": ag.TimeStamp,
+		"orgid":       ag.OrgID,
+		"timestamp":   ag.TimeStamp,
+		"owner_apiid": ag.OwnerAPIID,
 	}
 
 	updateDoc := ag.AnalyticsRecordAggregate.AsChange()

--- a/pumps/mcp_mongo_aggregate_test.go
+++ b/pumps/mcp_mongo_aggregate_test.go
@@ -57,6 +57,39 @@ func TestMCPMongoAggregatePump_Init_InvalidConfig(t *testing.T) {
 	require.Error(t, err, "Init should return error for invalid config")
 }
 
+func TestMCPMongoAggregatePump_WriteData_PerAPIPartitioning(t *testing.T) {
+	pump := newMCPMongoAggregatePump(t)
+
+	ts := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	records := []interface{}{
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-A", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-A", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-A", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-A", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-A", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-B", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+		analytics.AnalyticsRecord{TimeStamp: ts, APIID: "api-B", OrgID: "org1", ResponseCode: 200, MCPStats: analytics.MCPStats{IsMCP: true, JSONRPCMethod: "tools/call", PrimitiveType: "tool", PrimitiveName: "get_anything"}},
+	}
+
+	require.NoError(t, pump.WriteData(context.Background(), records))
+
+	var results []analytics.MCPRecordAggregate
+	require.NoError(t, pump.store.Query(
+		context.Background(),
+		&analytics.MCPRecordAggregate{AnalyticsRecordAggregate: analytics.AnalyticsRecordAggregate{Mixed: true}},
+		&results,
+		model.DBM{"orgid": "org1"},
+	))
+
+	require.Len(t, results, 2, "expected one mixed-collection doc per api, got %d (cross-api merge regression)", len(results))
+
+	hits := []int{results[0].Total.Hits, results[1].Total.Hits}
+	if hits[0] > hits[1] {
+		hits[0], hits[1] = hits[1], hits[0]
+	}
+	assert.Equal(t, []int{2, 5}, hits, "expected per-api hit counts {2,5}, got %v (a single merged doc would show 7)", hits)
+}
+
 func TestMCPMongoAggregatePump_WriteData_Roundtrip(t *testing.T) {
 	pump := newMCPMongoAggregatePump(t)
 


### PR DESCRIPTION
## Summary

The `MCPMongoAggregatePump` upsert query only matched on `(orgid, timestamp)`, so concurrent writes from two MCP proxies in the same time bucket merged into a single document. Dashboard queries scoped to a single api (`apiid.<X>: \$exists`) still matched the merged doc; unwinding `lists.names` returned counters from BOTH proxies; queries reported the sum (e.g. 5+2=7) instead of one proxy's traffic.

## Fix

- Add `OwnerAPIID` (bson `owner_apiid`) to `MCPRecordAggregate`.
- Populate it in `initMCPAggregateForRecord` from `record.APIID`.
- Include it in the upsert query in `pumps/mcp_mongo_aggregate.go` so each `(org, timestamp, api)` gets its own document.

Each MCP doc now holds a single api's `lists.names` entries and the existing dashboard queries are correct.

## Test plan

- Reproduced by tyk-analytics test `TestMCPAnalyticsProxyFilter::test_api_id_filter_scopes_results_to_selected_proxy` (added in tyk-analytics PR #5514).
- Existing pump unit tests in `analytics/aggregate_mcp_test.go` and `pumps/mcp_mongo_aggregate_test.go` continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)