### PR TITLE
[TT-17339 master] Implement Floating tags in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ env:
 jobs:
   dep-guard:
     if: github.event_name == 'pull_request'
-    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@d3fa20888fa2878e877e22bb7702141217290e7c # main
+    uses: TykTechnologies/github-actions/.github/workflows/dependency-guard.yml@production
     permissions:
       contents: read
   goreleaser:
@@ -44,7 +44,7 @@ jobs:
       (needs.dep-guard.result == 'success' || needs.dep-guard.result == 'skipped') &&
       github.event.pull_request.draft == false
     name: '${{ matrix.golang_cross }}'
-    runs-on: ${{ vars.DEFAULT_RUNNER }}
+    runs-on: ${{ vars.BUILD_RUNNER || vars.DEFAULT_RUNNER }}
     permissions:
       id-token: write # AWS OIDC JWT
       contents: read # actions/checkout
@@ -170,11 +170,10 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
-          push: true
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.ci_metadata_fips.outputs.tags }}
@@ -183,8 +182,23 @@ jobs:
             BUILD_PACKAGE_NAME=tyk-pump-fips
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
+      - name: Verify compression format for fips CI image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: Docker metadata for fips tag push
         id: tag_metadata_fips
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -201,23 +215,35 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
           platforms: linux/amd64,linux/arm64
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           tags: ${{ steps.tag_metadata_fips.outputs.tags }}
           labels: ${{ steps.tag_metadata_fips.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump-fips
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
+      - name: Verify compression format for fips prod image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
         if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
@@ -251,19 +277,33 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
-          push: true
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           cache-from: type=gha
           cache-to: type=gha,mode=max
           tags: ${{ steps.ci_metadata_std.outputs.tags }}
           labels: ${{ steps.ci_metadata_std.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
+      - name: Verify compression format for std CI image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: Docker metadata for std tag push
         id: tag_metadata_std
+        if: startsWith(github.ref, 'refs/tags')
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -281,21 +321,33 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
           platforms: linux/amd64,linux/arm64
           file: ci/Dockerfile.distroless
           provenance: mode=max
-          sbom: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: ${{ startsWith(github.ref, 'refs/tags') }}
+          outputs: type=image,push=true,compression=gzip,force-compression=true,oci-mediatypes=true
           tags: ${{ steps.tag_metadata_std.outputs.tags }}
           labels: ${{ steps.tag_metadata_std.outputs.labels }}
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
+      - name: Verify compression format for std prod image
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        run: |
+          # Resolve the first tag for verification
+          TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
+          echo "Inspecting layer compression for tag: $TAG"
+
+          docker buildx imagetools inspect --raw "$TAG" > manifest.json
+          if grep -q "tar+zstd" manifest.json; then
+            echo "::error::Image contains zstd-compressed layers! This is incompatible with legacy registries."
+            cat manifest.json | grep mediaType
+            exit 1
+          fi
+          echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ matrix.golang_cross == '1.25-bookworm' }}
@@ -330,7 +382,7 @@ jobs:
       sink: ${{ steps.params.outputs.sink }}
     steps:
       - name: Set test parameters
-        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/test-controller@production
         id: params
         with:
           variation: ${{ env.VARIATION }}
@@ -342,8 +394,7 @@ jobs:
       - goreleaser
     if: |
       !cancelled() &&
-      needs.goreleaser.result == 'success' &&
-      needs.test-controller-api.result == 'success'
+      needs.goreleaser.result == 'success'
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     env:
       XUNIT_REPORT_PATH: ${{ github.workspace}}/test-results.xml
@@ -381,11 +432,11 @@ jobs:
           # Only ${{ github.actor }} has access
           # See https://github.com/mxschmitt/action-tmate#use-registered-public-ssh-keys
       - name: Fetch environment from tyk-pro
-        uses: TykTechnologies/github-actions/.github/actions/tests/checkout-tyk-pro@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/checkout-tyk-pro@production
         with:
-          org_gh_token: ${{ github.token }}
+          org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Set up test environment
-        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/env-up@production
         timeout-minutes: 5
         id: env_up
         with:
@@ -395,18 +446,18 @@ jobs:
           TYK_DB_LICENSEKEY: ${{ secrets.DASH_LICENSE }}
           TYK_MDCB_LICENSE: ${{ secrets.MDCB_LICENSE }}
       - name: Choose test code branch
-        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/choose-test-branch@production
         with:
           test_folder: api
           org_gh_token: ${{ steps.app-token.outputs.token }}
       - name: Run API tests
-        uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/api-tests@production
         timeout-minutes: 45
         id: test_execution
         with:
           user_api_secret: ${{ steps.env_up.outputs.USER_API_SECRET }}
       - name: Generate test reports and collect logs
-        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@42304edda365365e0a887cf018d8edc34b960b82 # main
+        uses: TykTechnologies/github-actions/.github/actions/tests/reporting@production
         if: always() && (steps.test_execution.conclusion != 'skipped')
         with:
           report_xml: 'true'
@@ -472,9 +523,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:
@@ -522,9 +570,6 @@ jobs:
     runs-on: ${{ vars.DEFAULT_RUNNER }}
     needs:
       - test-controller-distros
-    if: |
-      !cancelled() &&
-      needs.test-controller-distros.result == 'success'
     strategy:
       fail-fast: true
       matrix:

--- a/ci/Dockerfile.distroless
+++ b/ci/Dockerfile.distroless
@@ -13,6 +13,8 @@ COPY ${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb /
 ARG NONROOT_CHOWN=false
 RUN dpkg -i /${BUILD_PACKAGE_NAME}_*${TARGETARCH}.deb && rm /*.deb \
     && chmod -R a+rX /opt/tyk-pump/ \
+    && mkdir -p /opt/tyk-pump/middleware/bundles \
+    && chmod a+rwX /opt/tyk-pump/middleware /opt/tyk-pump/middleware/bundles \
     && if [ "$NONROOT_CHOWN" = "true" ]; then chown -R 65532:65532 /opt/tyk-pump/; fi
 
 FROM ${BASE_IMAGE}


### PR DESCRIPTION
Maintain a mutable tag (e.g. production) in the GitHub Actions repo, moved to the latest commit. Product repos reference @production and pick up updates automatically.
This is a follow up of the Spike ticket: https://tyktech.atlassian.net/jira/software/c/projects/TT/boards/451?assignee=5ed4afcb53ec400c2c067d80&selectedIssue=TT-17303 
