### PR TITLE
[DX-2351] Correct listen_address description for Prometheus pump

### DIFF
--- a/pumps/prometheus.go
+++ b/pumps/prometheus.go
@@ -35,7 +35,7 @@ type PrometheusConf struct {
 	// Prefix for the environment variables that will be used to override the configuration.
 	// Defaults to `TYK_PMP_PUMPS_PROMETHEUS_META`
 	EnvPrefix string `mapstructure:"meta_env_prefix"`
-	// The full URL to your Prometheus instance, {HOST}:{PORT}. For example `localhost:9090`.
+	// The address and port on which Tyk Pump exposes the Prometheus metrics endpoint for Prometheus to scrape, in the form {HOST}:{PORT}. For example `localhost:9090`.
 	Addr string `json:"listen_address" mapstructure:"listen_address"`
 	// The path to the Prometheus collection. For example `/metrics`.
 	Path string `json:"path" mapstructure:"path"`


### PR DESCRIPTION
## Jira

[DX-2351](https://tyktech.atlassian.net/browse/DX-2351) — Incorrect description of `pumps.prometheus.meta.listen_address` in the docs (customer escalation, Zendesk #18830).

## Problem

The doc comment for the Prometheus pump's `listen_address` field in `pumps/prometheus.go` described the value as:

> The full URL to your Prometheus instance, {HOST}:{PORT}. For example `localhost:9090`.

This is incorrect and has caused customer confusion. The field is **not** a URL pointing at a Prometheus instance. The pump binds to this address and serves its metrics endpoint there:

```go
p.log.Info("Starting prometheus listener on:", p.conf.Addr)
...
log.Fatal(http.ListenAndServe(p.conf.Addr, nil))
```

So `listen_address` is the `address:port` that Tyk Pump listens on so that Prometheus can scrape it. This also contradicted the (correct) explanation on the [Monitor your APIs with Prometheus](https://tyk.io/docs/api-management/tyk-pump/#monitor-your-apis-with-prometheus) docs page.

## Fix

Correct the struct doc comment so it accurately describes the field:

```go
// The address and port on which Tyk Pump exposes the Prometheus metrics endpoint for Prometheus to scrape, in the form {HOST}:{PORT}. For example `localhost:9090`.
```

This comment is the source for the auto-generated Tyk Pump configuration and environment-variable reference pages in tyk-docs (`snippets/pump-config.mdx`), so the correction propagates to the published documentation on the next docs sync. No behaviour change.

[DX-2351]: https://tyktech.atlassian.net/browse/DX-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ