### PR TITLE
TT-17868 upgrade Go version to 1.26.5

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -26,7 +26,7 @@ jobs:
         mongodb-version: [4.2]
         postgres-version: [15]
         mysql-version: ["8.0"]
-        go: [1.25]
+        go: [1.26]
 
     services:
       redis:

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -105,7 +105,7 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         timeout-minutes: 20
         with:
-          version: v2.5.0
+          version: v2.12.2
           only-new-issues: ${{ github.event_name == 'pull_request' }}
           # Output formats configured in .golangci.yaml (v2 approach)
           # Generates: text to stdout + checkstyle JSON for SonarQube

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.25]
+        go: [1.26]
     services:
       redis:
         image: redis:5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.26-bookworm
+          - 1.26-bullseye
         include:
-          - golang_cross: 1.26-bookworm
+          - golang_cross: 1.26-bullseye
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -448,7 +448,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -462,7 +462,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -506,7 +506,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         with:
           name: deb
           retention-days: 1
@@ -516,7 +516,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
         with:
           name: rpm
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.26-bullseye
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.26-bullseye
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -448,7 +448,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -462,7 +462,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.26-bullseye' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -506,7 +506,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -516,7 +516,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bullseye' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.25-bookworm
+          - 1.26-bookworm
         include:
-          - golang_cross: 1.25-bookworm
+          - golang_cross: 1.26-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -448,7 +448,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -462,7 +462,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -506,7 +506,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -516,7 +516,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,9 +52,9 @@ jobs:
       fail-fast: false
       matrix:
         golang_cross:
-          - 1.26-bookworm
+          - 1.25-bookworm
         include:
-          - golang_cross: 1.26-bookworm
+          - golang_cross: 1.25-bookworm
             goreleaser: 'ci/goreleaser/goreleaser.yml'
             cgo: 0
             rpmvers: 'el/7 el/8 el/9 amazon/2 amazon/2023'
@@ -107,7 +107,7 @@ jobs:
           mask-aws-account-id: false
       - uses: aws-actions/amazon-ecr-login@f2e9fc6c2b355c1890b65e6f6f0e2ac3e6e22f78 # v2
         id: ecr
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           mask-password: 'true'
       - uses: WarpBuilds/cache@f643a1ba29942d56621d07fc2d4284c7219868ad # v1
@@ -184,7 +184,7 @@ jobs:
           -w /go/src/github.com/TykTechnologies/tyk-pump                      \
           tykio/golang-cross:${{ matrix.golang_cross }} /tmp/build.sh
       - name: Install Docker Scout CLI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir -p ~/.docker/cli-plugins
           curl --proto '=https' --tlsv1.2 -fsSL https://github.com/docker/scout-cli/releases/download/v1.22.0/docker-scout_1.22.0_linux_amd64.tar.gz -o /tmp/scout.tar.gz
@@ -194,7 +194,7 @@ jobs:
           chmod +x ~/.docker/cli-plugins/docker-scout
       - name: Docker metadata for fips CI
         id: ci_metadata_fips
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -209,7 +209,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push fips image to CI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -226,7 +226,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips CI image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -287,7 +287,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push fips image to prod
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -303,7 +303,7 @@ jobs:
             BASE_IMAGE=tykio/dhi-busybox:1.37-fips
             NONROOT_CHOWN=true
       - name: Verify compression format for fips prod image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_fips.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -346,7 +346,7 @@ jobs:
           fi
           echo "Success: All layers are uniformly compressed using gzip."
       - name: Attach base image VEX to fips
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           docker scout vex get --org tykio -o /tmp/fips-vex.json tykio/dhi-busybox:1.37-fips || true
           if [ -f /tmp/fips-vex.json ]; then
@@ -356,7 +356,7 @@ jobs:
           fi
       - name: Docker metadata for std CI
         id: ci_metadata_std
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
@@ -371,7 +371,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},prefix=v
             type=semver,pattern={{version}},prefix=v
       - name: push std image to CI
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -386,7 +386,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std CI image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.ci_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -448,7 +448,7 @@ jobs:
             org.opencontainers.image.vendor=tyk.io
             org.opencontainers.image.version=${{ github.ref_name }}
       - name: push std image to prod
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: "dist"
@@ -462,7 +462,7 @@ jobs:
           build-args: |
             BUILD_PACKAGE_NAME=tyk-pump
       - name: Verify compression format for std prod image
-        if: ${{ matrix.golang_cross == '1.26-bookworm' && startsWith(github.ref, 'refs/tags') }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' && startsWith(github.ref, 'refs/tags') }}
         run: |
           # Resolve the first tag for verification
           TAG=$(echo "${{ steps.tag_metadata_std.outputs.tags }}" | tr ',' '\n' | head -n1)
@@ -506,7 +506,7 @@ jobs:
           echo "Success: All layers are uniformly compressed using gzip."
       - name: save deb
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           name: deb
           retention-days: 1
@@ -516,7 +516,7 @@ jobs:
             !dist/*fips*.deb
       - name: save rpm
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: ${{ matrix.golang_cross == '1.26-bookworm' }}
+        if: ${{ matrix.golang_cross == '1.25-bookworm' }}
         with:
           name: rpm
           retention-days: 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25@sha256:83978e9c0c95d28fe29a9be9095b45d42c8d2ee75c3243f32b0dd1f0daec9043 as builder
+FROM golang:1.26@sha256:2005724102f45917a63e9d092fc0e4ea56ea575048ce147caad5f5f61502c365 as builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TykTechnologies/tyk-pump
 
-go 1.25.0
+go 1.26.5
 
 require (
 	github.com/DataDog/datadog-go v4.7.0+incompatible


### PR DESCRIPTION
Upgrading Go to 1.26.

Prior the upgrade the spike proved it should be safe to perform the upgrade.







<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17868" title="TT-17868" target="_blank">TT-17868</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | Update Tyk components to Go 1.26 |

Generated at: 2026-08-07 10:56:06

</details>

<!---TykTechnologies/jira-linter ends here-->







