### PR TITLE
TT-9424: Sort aggregate batches by ID to prevent PostgreSQL deadlocks

### DIFF
--- a/pumps/graph_sql_aggregate.go
+++ b/pumps/graph_sql_aggregate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/mitchellh/mapstructure"
@@ -173,6 +174,9 @@ func (s *GraphSQLAggregatePump) DoAggregatedWriting(ctx context.Context, table, 
 		rec.Counter.ErrorMap = nil
 		recs = append(recs, rec)
 	}
+
+	// Deterministic lock ordering - see the note in SQLAggregatePump.DoAggregatedWriting (TT-9424).
+	sort.Slice(recs, func(i, j int) bool { return recs[i].ID < recs[j].ID })
 
 	for i := 0; i < len(recs); i += s.SQLConf.BatchSize {
 		ends := i + s.SQLConf.BatchSize

--- a/pumps/graph_sql_aggregate_test.go
+++ b/pumps/graph_sql_aggregate_test.go
@@ -669,3 +669,58 @@ func TestGraphSQLAggregatePump_WriteData_Sharded(t *testing.T) {
 		assert.NotEmpty(t, aggr, "table %s does not contain records", secondShardedTable)
 	})
 }
+
+// TestGraphSQLAggregatePump_DoAggregatedWriting_SQLite exercises the graph aggregate write
+// path against in-memory SQLite, so it runs everywhere - including the coverage CI job, which
+// provisions no PostgreSQL and therefore skips every Postgres-gated test in this package.
+//
+// Init() is deliberately not called: Dialect() has not supported sqlite since v1.12.0, so the
+// pump is built directly over the test database, mirroring newMCPSQLAggregatePumpWithSQLite.
+//
+// The deterministic batch ordering this path relies on (TT-9424) is asserted directly by
+// TestTT9424SortDeterminism and exercised under real contention by
+// TestTT9424GraphAggregateNoDeadlock; this test covers the write path itself.
+func TestGraphSQLAggregatePump_DoAggregatedWriting_SQLite(t *testing.T) {
+	db := setupTestDBWithJSONTags(t)
+	tableName := analytics.AggregateGraphSQLTable
+	require.NoError(t, db.Table(tableName).AutoMigrate(&analytics.GraphSQLAnalyticsRecordAggregate{}))
+
+	pump := &GraphSQLAggregatePump{
+		db: db,
+		SQLConf: &SQLAggregatePumpConf{
+			SQLConf: SQLConf{BatchSize: 100},
+		},
+	}
+	pump.log = log.WithField("prefix", SQLAggregatePumpPrefix)
+
+	ag := &analytics.GraphRecordAggregate{
+		Types:      map[string]*analytics.Counter{},
+		Fields:     map[string]*analytics.Counter{},
+		Operation:  map[string]*analytics.Counter{},
+		RootFields: map[string]*analytics.Counter{},
+	}
+	ag.TimeStamp = time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	ag.OrgID = "org1"
+	// Dimensions() always appends a "total" row built from this counter, and it must carry
+	// hits: the on-conflict assignment for request_time averages over
+	// (existing hits + incoming hits), which divides by zero when both sides are empty.
+	ag.Total = analytics.Counter{Hits: 4, Success: 4}
+	for i := 0; i < 4; i++ {
+		suffix := fmt.Sprintf("%02d", i)
+		ag.Types["Type"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+		ag.Fields["field"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+	}
+
+	require.NoError(t, pump.DoAggregatedWriting(context.Background(), tableName, "org1", "api1", ag))
+
+	var recs []analytics.GraphSQLAnalyticsRecordAggregate
+	require.NoError(t, pump.db.Table(tableName).Find(&recs).Error)
+
+	// 4 types + 4 fields + the implicit "total" row.
+	assert.Len(t, recs, 9)
+	for _, rec := range recs {
+		assert.Equal(t, "org1", rec.OrgID)
+		assert.Equal(t, "api1", rec.APIID)
+		assert.NotEmpty(t, rec.ID)
+	}
+}

--- a/pumps/mcp_sql_aggregate.go
+++ b/pumps/mcp_sql_aggregate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/mitchellh/mapstructure"
@@ -250,6 +251,9 @@ func (s *MCPSQLAggregatePump) DoAggregatedWriting(ctx context.Context, table, or
 		rec.Counter.ErrorMap = nil
 		recs = append(recs, rec)
 	}
+
+	// Deterministic lock ordering - see the note in SQLAggregatePump.DoAggregatedWriting (TT-9424).
+	sort.Slice(recs, func(i, j int) bool { return recs[i].ID < recs[j].ID })
 
 	for i := 0; i < len(recs); i += s.SQLConf.BatchSize {
 		ends := i + s.SQLConf.BatchSize

--- a/pumps/mcp_sql_aggregate_test.go
+++ b/pumps/mcp_sql_aggregate_test.go
@@ -110,7 +110,14 @@ func TestMCPSQLAggregatePump_WriteData(t *testing.T) {
 	skipTestIfNoPostgres(t)
 	tableName := analytics.AggregateMCPSQLTable
 
+	// OmitIndexCreation keeps Init from spawning the background CREATE INDEX
+	// CONCURRENTLY goroutine. That goroutine outlives the subtest that started it and
+	// races the subtest's DROP TABLE cleanup; when the drop loses, the next subtest finds
+	// the table still populated, its writes accumulate onto the stale rows, and the
+	// expected counts no longer match. Index creation is covered by the Init subtests
+	// above and by TestEnsureIndexSQLAggregate, so nothing is lost here.
 	conf := SQLAggregatePumpConf{
+		OmitIndexCreation: true,
 		SQLConf: SQLConf{
 			Type:             "postgres",
 			ConnectionString: getTestPostgresConnectionString(),

--- a/pumps/sql.go
+++ b/pumps/sql.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 	"time"
 
@@ -400,6 +401,11 @@ func (c *SQLPump) WriteUptimeData(data []interface{}) {
 
 				recs = append(recs, rec)
 			}
+
+			// Deterministic lock ordering - see the note in SQLAggregatePump.DoAggregatedWriting
+			// (TT-9424). recs is rebuilt per org and per day-shard, so this must stay in the
+			// innermost scope: hoisting it out would leave later orgs and shards unsorted.
+			sort.Slice(recs, func(i, j int) bool { return recs[i].ID < recs[j].ID })
 
 			for i := 0; i < len(recs); i += c.SQLConf.BatchSize {
 				ends := i + c.SQLConf.BatchSize

--- a/pumps/sql_aggregate.go
+++ b/pumps/sql_aggregate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"sort"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 
@@ -293,6 +294,12 @@ func (c *SQLAggregatePump) DoAggregatedWriting(ctx context.Context, table, orgID
 		rec.Counter.ErrorMap = nil
 		recs = append(recs, rec)
 	}
+
+	// Sort by ID so every replica requests row locks in the same order. Dimensions()
+	// ranges over maps, so without this the row order - and therefore PostgreSQL's
+	// lock acquisition order - differs per process, deadlocking concurrent upserts
+	// of overlapping IDs (TT-9424).
+	sort.Slice(recs, func(i, j int) bool { return recs[i].ID < recs[j].ID })
 
 	for i := 0; i < len(recs); i += c.SQLConf.BatchSize {
 		ends := i + c.SQLConf.BatchSize

--- a/pumps/sql_deadlock_ordering_test.go
+++ b/pumps/sql_deadlock_ordering_test.go
@@ -1,0 +1,534 @@
+package pumps
+
+// TT-9424 regression tests.
+//
+// The SQL aggregate pumps build their upsert batches by ranging over the maps
+// returned from Dimensions(). Go randomises map iteration per process, and
+// PostgreSQL takes row locks in statement order, so two pump replicas upserting
+// overlapping IDs in opposite orders form a circular wait and one transaction is
+// aborted with "deadlock detected (SQLSTATE 40P01)". The aborted batch is not
+// retried, so the purge cycle's aggregates are silently lost.
+//
+// The fix sorts each batch by row ID before the upsert, giving every replica the
+// same lock acquisition order. These tests stand up several independently
+// initialised pumps (separate DB connections, mirroring separate pods) writing an
+// overlapping batch concurrently, and assert that no deadlock occurs.
+//
+// Run with:
+//
+//	TYK_TEST_POSTGRES="host=localhost port=5433 user=postgres password=test \
+//	  dbname=tyk_analytics sslmode=disable" \
+//	  go test ./pumps -run TestTT9424 -v -count=1
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/TykTechnologies/tyk-pump/analytics"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/vmihailenco/msgpack.v2"
+)
+
+const (
+	// Simulated pump replicas. Three is enough to produce a circular wait
+	// reliably while keeping the run short.
+	tt9424Replicas = 3
+	// Purge cycles per replica.
+	tt9424Iterations = 15
+	// Distinct APIs per cycle for the standard aggregate pump. Yields 756
+	// dimensions - see the note below on why that number matters.
+	tt9424Cardinality = 150
+)
+
+// A warning about workload shape, because it is not obvious and it is easy to
+// break these tests into ones that pass whether or not the bug is present.
+//
+// How often the deadlock reproduces is very sensitive to the shape of the
+// batch, and not in the direction you would guess - piling on more data makes
+// it reproduce *less*. Measured on an unfixed tree, three replicas, against
+// the graph pump:
+//
+//	 749 rows from 4 dimension maps  ->   0/45  cycles deadlocked
+//	1310 rows from 7 dimension maps  ->  24/45  cycles deadlocked
+//	2001 rows from 4 dimension maps  ->   2/120 cycles deadlocked
+//	3501 rows from 7 dimension maps  ->   3/120 cycles deadlocked
+//
+// The fixtures below sit on the 1310-row shape, and each was confirmed to fail
+// against an unfixed tree before being committed. Treat those numbers as
+// measurements of these fixtures, not as a general model of the bug: the
+// mechanism is nondeterministic lock ordering, and reproduction rate is not
+// fully characterised beyond the points above.
+//
+// So if you change a cardinality, the number of dimension maps, or the batch
+// size here, re-verify by reverting the sort.Slice calls in the four pumps and
+// checking these tests still fail. Otherwise you may quietly be shipping a
+// guard that no longer guards anything.
+
+// Dimension counts per DoAggregatedWriting call. Graph and MCP each populate
+// their own dimension maps plus three from the embedded AnalyticsRecordAggregate.
+const (
+	tt9424GraphCardinality  = 187 // 7 maps * 187 + 1 total = 1310 rows
+	tt9424MCPCardinality    = 250 // 6 maps * 250 + 1 total = 1501 rows
+	tt9424UptimeCardinality = 750 // 750 URLs + 1 total = 751 rows
+)
+
+// tt9424Collector accumulates errors from concurrent replicas and counts how
+// many were PostgreSQL deadlocks.
+type tt9424Collector struct {
+	mu        sync.Mutex
+	errs      []error
+	deadlocks int
+}
+
+func (c *tt9424Collector) record(err error) {
+	if err == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.errs = append(c.errs, err)
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "40p01") || strings.Contains(msg, "deadlock") {
+		c.deadlocks++
+	}
+}
+
+// assertNoDeadlocks fails the test if any replica hit a deadlock, and fails on
+// any other write error too - a lost batch is a lost batch whatever aborted it.
+func (c *tt9424Collector) assertNoDeadlocks(t *testing.T) {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i, err := range c.errs {
+		if i >= 5 {
+			t.Logf("... and %d more errors", len(c.errs)-5)
+			break
+		}
+		t.Logf("write error %d: %v", i, err)
+	}
+	if c.deadlocks > 0 {
+		t.Fatalf("TT-9424 regression: %d deadlock(s) (SQLSTATE 40P01) across %d write errors; "+
+			"batches must be sorted by ID so every replica locks rows in the same order",
+			c.deadlocks, len(c.errs))
+	}
+	if len(c.errs) > 0 {
+		t.Fatalf("TT-9424: %d write error(s) with no deadlock - see log above", len(c.errs))
+	}
+}
+
+// tt9424RunReplicas runs write once per iteration on each replica, all replicas
+// concurrently, and returns the collected errors.
+func tt9424RunReplicas(replicas int, iterations int, write func(replica, iteration int) error) *tt9424Collector {
+	collector := &tt9424Collector{}
+
+	var wg sync.WaitGroup
+	for r := 0; r < replicas; r++ {
+		wg.Add(1)
+		go func(replica int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				collector.record(write(replica, i))
+			}
+		}(r)
+	}
+	wg.Wait()
+
+	return collector
+}
+
+// tt9424Suffix produces a short deterministic label for index i, distinct for
+// every i below 10000. Distinctness matters: these tests assert exact row
+// counts, and colliding labels silently collapse dimensions into fewer rows.
+func tt9424Suffix(i int) string {
+	return fmt.Sprintf("%04d", i)
+}
+
+// tt9424AwaitIndex waits for a pump's background index creation to finish.
+//
+// The pumps only signal this channel when they actually create the index. With
+// several replicas sharing one database, the first replica creates it and the
+// rest find it already present and never signal - so this must not block
+// unconditionally the way the single-pump tests can afford to.
+func tt9424AwaitIndex(ch chan bool) {
+	if ch == nil {
+		return
+	}
+	select {
+	case <-ch:
+	case <-time.After(30 * time.Second):
+	}
+}
+
+// ── 1. Standard SQL aggregate pump ────────────────────────────────────────────
+
+// TestTT9424DeadlockRepro drives SQLAggregatePump.WriteData - the primary site
+// from the customer reports (tyk_aggregated / tyk_aggregated_YYYYMMDD).
+func TestTT9424DeadlockRepro(t *testing.T) {
+	skipTestIfNoPostgres(t)
+
+	for _, sharded := range []bool{false, true} {
+		name := "non-sharded"
+		if sharded {
+			name = "sharded"
+		}
+
+		t.Run(name, func(t *testing.T) {
+			// One pump instance per replica, each with its own gorm connection -
+			// the same shape as separate pods.
+			pumps := make([]*SQLAggregatePump, tt9424Replicas)
+			for i := 0; i < tt9424Replicas; i++ {
+				pmp := &SQLAggregatePump{}
+				cfg := newSQLConfig(sharded)
+				cfg["track_all_paths"] = true
+				require.NoErrorf(t, pmp.Init(cfg), "replica %d init failed", i)
+				tt9424AwaitIndex(pmp.backgroundIndexCreated)
+				pumps[i] = pmp
+			}
+
+			// Fixed timestamp: all replicas land in the same hour bucket and the
+			// same day shard, so they upsert an identical set of row IDs.
+			ts := time.Date(2099, 6, 1, 10, 0, 0, 0, time.UTC)
+			table := analytics.AggregateSQLTable
+			if sharded {
+				table = analytics.AggregateSQLTable + "_" + ts.Format("20060102")
+			}
+			t.Cleanup(func() { pumps[0].db.Migrator().DropTable(table) })
+
+			// All replicas process records for the SAME org and hour bucket.
+			// AggregateData stores dimensions in maps, so each replica emits the
+			// rows in a different (randomised) order.
+			keys := []string{"key-alpha", "key-beta", "key-gamma", "key-delta"}
+			makeRecords := func() []interface{} {
+				recs := make([]interface{}, 0, tt9424Cardinality*2)
+				for i := 0; i < tt9424Cardinality; i++ {
+					suffix := tt9424Suffix(i)
+					rec := analytics.AnalyticsRecord{
+						OrgID:        "org-tt9424",
+						APIID:        "api-" + suffix,
+						APIName:      "API " + suffix,
+						APIKey:       keys[i%len(keys)],
+						APIVersion:   "v1",
+						Path:         "/path-" + suffix,
+						Method:       "GET",
+						ResponseCode: 200,
+						TimeStamp:    ts,
+						RequestTime:  10,
+					}
+					recs = append(recs, rec)
+					errRec := rec
+					errRec.ResponseCode = 500
+					recs = append(recs, errRec)
+				}
+				return recs
+			}
+
+			// Warm up on a single replica first. In the sharded case the day
+			// table is created lazily on first write, and three replicas racing
+			// to CreateTable the same shard trip a unique violation on the
+			// catalogue. That startup race is a separate pre-existing issue;
+			// creating the shard up front keeps this test on lock ordering.
+			require.NoError(t, pumps[0].WriteData(context.Background(), makeRecords()))
+
+			collector := tt9424RunReplicas(tt9424Replicas, tt9424Iterations, func(replica, _ int) error {
+				return pumps[replica].WriteData(context.Background(), makeRecords())
+			})
+			collector.assertNoDeadlocks(t)
+		})
+	}
+}
+
+// ── 2. Graph SQL aggregate pump ───────────────────────────────────────────────
+
+// TestTT9424GraphAggregateNoDeadlock drives GraphSQLAggregatePump.DoAggregatedWriting
+// directly. Building the aggregate by hand rather than going through WriteData
+// keeps the dimension cardinality under the test's control and avoids the
+// GraphQL request/response parsing machinery, which is irrelevant to lock order.
+//
+// The cardinality is deliberately sized to one statement - see the workload
+// shape note at the top of this file before changing it.
+func TestTT9424GraphAggregateNoDeadlock(t *testing.T) {
+	skipTestIfNoPostgres(t)
+
+	pumps := make([]*GraphSQLAggregatePump, tt9424Replicas)
+	for i := 0; i < tt9424Replicas; i++ {
+		pmp := &GraphSQLAggregatePump{}
+		require.NoErrorf(t, pmp.Init(newSQLConfig(false)), "replica %d init failed", i)
+		pumps[i] = pmp
+	}
+	t.Cleanup(func() { pumps[0].db.Migrator().DropTable(analytics.AggregateGraphSQLTable) })
+
+	ts := time.Date(2099, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	// Each replica rebuilds the aggregate per cycle so the maps are re-ranged
+	// (and so re-randomised) every time.
+	makeAggregate := func() *analytics.GraphRecordAggregate {
+		ag := &analytics.GraphRecordAggregate{
+			Types:      map[string]*analytics.Counter{},
+			Fields:     map[string]*analytics.Counter{},
+			Operation:  map[string]*analytics.Counter{},
+			RootFields: map[string]*analytics.Counter{},
+		}
+		ag.TimeStamp = ts
+		ag.OrgID = "org-tt9424-graph"
+		// Dimensions() always appends a "total" dimension built from this
+		// counter. It must carry hits: the on-conflict assignment for
+		// request_time averages over (existing hits + incoming hits), which
+		// divides by zero if both sides are empty.
+		ag.Total = analytics.Counter{Hits: tt9424GraphCardinality, Success: tt9424GraphCardinality}
+		// The embedded AnalyticsRecordAggregate carries its own dimension maps,
+		// and real aggregation populates them. Leaving them nil produces a
+		// workload that does not reproduce the bug - see the shape note above.
+		ag.APIID = map[string]*analytics.Counter{}
+		ag.APIKeys = map[string]*analytics.Counter{}
+		ag.Endpoints = map[string]*analytics.Counter{}
+		for i := 0; i < tt9424GraphCardinality; i++ {
+			suffix := tt9424Suffix(i)
+			ag.APIID["api-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.APIKeys["key-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Endpoints["endpoint-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Types["Type"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Fields["field"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Operation["op"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.RootFields["root"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+		}
+		return ag
+	}
+
+	collector := tt9424RunReplicas(tt9424Replicas, tt9424Iterations, func(replica, _ int) error {
+		return pumps[replica].DoAggregatedWriting(
+			context.Background(),
+			analytics.AggregateGraphSQLTable,
+			"org-tt9424-graph",
+			"api-tt9424-graph",
+			makeAggregate(),
+		)
+	})
+	collector.assertNoDeadlocks(t)
+}
+
+// ── 3. MCP SQL aggregate pump ─────────────────────────────────────────────────
+
+// TestTT9424MCPAggregateNoDeadlock drives MCPSQLAggregatePump.DoAggregatedWriting.
+// As with the graph test, the cardinality is sized to one statement - see the
+// workload shape note at the top of this file.
+func TestTT9424MCPAggregateNoDeadlock(t *testing.T) {
+	skipTestIfNoPostgres(t)
+
+	pumps := make([]*MCPSQLAggregatePump, tt9424Replicas)
+	for i := 0; i < tt9424Replicas; i++ {
+		pmp := &MCPSQLAggregatePump{}
+		require.NoErrorf(t, pmp.Init(newSQLConfig(false)), "replica %d init failed", i)
+		tt9424AwaitIndex(pmp.backgroundIndexCreated)
+		pumps[i] = pmp
+	}
+	t.Cleanup(func() { pumps[0].db.Migrator().DropTable(analytics.AggregateMCPSQLTable) })
+
+	ts := time.Date(2099, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	makeAggregate := func() *analytics.MCPRecordAggregate {
+		ag := analytics.NewMCPRecordAggregate()
+		ag.TimeStamp = ts
+		ag.OrgID = "org-tt9424-mcp"
+		ag.OwnerAPIID = "api-tt9424-mcp"
+		// See the note in the graph test: the implicit "total" dimension needs
+		// hits or the averaging on-conflict expression divides by zero.
+		ag.Total = analytics.Counter{Hits: tt9424MCPCardinality, Success: tt9424MCPCardinality}
+		// As in the graph test: the embedded dimension maps must be populated,
+		// the way real aggregation leaves them.
+		for i := 0; i < tt9424MCPCardinality; i++ {
+			suffix := tt9424Suffix(i)
+			ag.APIID["api-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.APIKeys["key-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Endpoints["endpoint-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Methods["tools/call-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Primitives["tool-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+			ag.Names["name-"+suffix] = &analytics.Counter{Hits: 1, Success: 1}
+		}
+		return &ag
+	}
+
+	collector := tt9424RunReplicas(tt9424Replicas, tt9424Iterations, func(replica, _ int) error {
+		return pumps[replica].DoAggregatedWriting(
+			context.Background(),
+			analytics.AggregateMCPSQLTable,
+			"org-tt9424-mcp",
+			"api-tt9424-mcp",
+			makeAggregate(),
+		)
+	})
+	collector.assertNoDeadlocks(t)
+}
+
+// ── 4. Uptime SQL pump ────────────────────────────────────────────────────────
+
+// TestTT9424UptimeNoDeadlock drives SQLPump.WriteUptimeData.
+//
+// WriteUptimeData only logs write errors, so a deadlock is invisible to the
+// caller. The test detects it by consequence instead: an aborted transaction
+// loses its whole batch, so the accumulated hit counts come up short.
+//
+// The workload spans several organisations, each producing one statement's
+// worth of dimensions. That covers the placement constraint - recs is rebuilt
+// per org, so the sort has to sit inside the per-org loop. Hoisted above it,
+// every org after the first is upserted unsorted and starts deadlocking.
+func TestTT9424UptimeNoDeadlock(t *testing.T) {
+	skipTestIfNoPostgres(t)
+
+	orgs := []string{"org-tt9424-uptime-a", "org-tt9424-uptime-b", "org-tt9424-uptime-c"}
+
+	pumps := make([]*SQLPump, tt9424Replicas)
+	for i := 0; i < tt9424Replicas; i++ {
+		pmp := &SQLPump{IsUptime: true}
+		require.NoErrorf(t, pmp.Init(newSQLConfig(false)), "replica %d init failed", i)
+		pumps[i] = pmp
+	}
+	t.Cleanup(func() { pumps[0].db.Migrator().DropTable(analytics.UptimeSQLTable) })
+
+	ts := time.Date(2099, 6, 1, 10, 0, 0, 0, time.UTC)
+
+	// Uptime dimensions come from the URL map, so distinct URLs drive the row
+	// count. Each org gets tt9424UptimeCardinality URLs plus a "total" row,
+	// which stays inside one batch at the default batch size.
+	makeRecords := func() []interface{} {
+		out := make([]interface{}, 0, len(orgs)*tt9424UptimeCardinality)
+		for _, org := range orgs {
+			for i := 0; i < tt9424UptimeCardinality; i++ {
+				rec := analytics.UptimeReportData{
+					OrgID:        org,
+					URL:          "https://upstream.example/" + tt9424Suffix(i),
+					APIID:        "api-tt9424-uptime",
+					ResponseCode: 200,
+					RequestTime:  10,
+					TimeStamp:    ts,
+				}
+				encoded, err := msgpack.Marshal(rec)
+				require.NoError(t, err)
+				out = append(out, string(encoded))
+			}
+		}
+		return out
+	}
+
+	tt9424RunReplicas(tt9424Replicas, tt9424Iterations, func(replica, _ int) error {
+		pumps[replica].WriteUptimeData(makeRecords())
+		return nil
+	})
+
+	// Per org: one row per URL plus the "total" row.
+	wantRows := int64(len(orgs) * (tt9424UptimeCardinality + 1))
+	var gotRows int64
+	require.NoError(t, pumps[0].db.Table(analytics.UptimeSQLTable).Count(&gotRows).Error)
+	require.Equalf(t, wantRows, gotRows,
+		"expected %d uptime aggregate rows; a short count means a batch was aborted (TT-9424 deadlock)", wantRows)
+
+	// Every record is a hit, so each org's total dimension must account for all
+	// of them. Checking every org is what catches a sort hoisted out of the
+	// per-org loop: the first org would still be fine, later ones would not.
+	wantHits := tt9424Replicas * tt9424Iterations * tt9424UptimeCardinality
+	for _, org := range orgs {
+		var total analytics.UptimeReportAggregateSQL
+		require.NoError(t, pumps[0].db.Table(analytics.UptimeSQLTable).
+			Where("dimension_value = ? AND org_id = ?", "total", org).
+			First(&total).Error)
+		require.Equalf(t, wantHits, total.Hits,
+			"org %s: total-dimension hits should account for every written record; a short count means a lost batch", org)
+	}
+}
+
+// ── 5. Sort determinism ───────────────────────────────────────────────────────
+
+// TestTT9424SortDeterminism asserts the property the fix actually depends on:
+// identical input produces an identical row order, and therefore identical batch
+// boundaries, no matter how Go happens to iterate the dimension maps this run.
+//
+// This is checked without a database. Dimensions() is called repeatedly on
+// equivalent aggregates and the resulting ID sequence - after the same sort the
+// pumps apply - must be byte-identical every time. Batch boundaries are derived
+// from that sequence and compared too: replica A's batch n and replica B's batch
+// n must cover the same ID set, which is what removes cross-batch contention on
+// top of the intra-statement lock ordering.
+func TestTT9424SortDeterminism(t *testing.T) {
+	const (
+		runs      = 32
+		batchSize = 50
+	)
+
+	// Build an aggregate whose dimensions come from maps - the source of the
+	// nondeterminism the sort has to absorb.
+	makeAggregate := func() *analytics.MCPRecordAggregate {
+		ag := analytics.NewMCPRecordAggregate()
+		ag.TimeStamp = time.Date(2099, 6, 1, 10, 0, 0, 0, time.UTC)
+		ag.OrgID = "org-determinism"
+		for i := 0; i < 200; i++ {
+			suffix := tt9424Suffix(i)
+			ag.Methods["m-"+suffix] = &analytics.Counter{Hits: 1}
+			ag.Primitives["p-"+suffix] = &analytics.Counter{Hits: 1}
+			ag.Names["n-"+suffix] = &analytics.Counter{Hits: 1}
+		}
+		return &ag
+	}
+
+	// idsFor mirrors what DoAggregatedWriting does: derive one ID per dimension,
+	// then sort. It deliberately does not reuse the pump method, so the test
+	// fails loudly if the sort is ever dropped from the pump but kept here.
+	idsFor := func(ag *analytics.MCPRecordAggregate, apiID string) []string {
+		var ids []string
+		for _, d := range ag.Dimensions() {
+			ids = append(ids, fmt.Sprintf("%v", ag.TimeStamp.Unix())+apiID+d.Name+d.Value)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		return ids
+	}
+
+	// Sanity check: without the sort the order really does vary run to run, so a
+	// passing determinism assertion below is meaningful rather than vacuous.
+	unsortedVaried := false
+	var firstUnsorted []string
+	for run := 0; run < runs && !unsortedVaried; run++ {
+		var ids []string
+		for _, d := range makeAggregate().Dimensions() {
+			ids = append(ids, d.Name+d.Value)
+		}
+		if run == 0 {
+			firstUnsorted = ids
+			continue
+		}
+		for i := range ids {
+			if ids[i] != firstUnsorted[i] {
+				unsortedVaried = true
+				break
+			}
+		}
+	}
+	require.True(t, unsortedVaried,
+		"map iteration did not vary across %d runs - this test can no longer prove the sort is doing anything", runs)
+
+	want := idsFor(makeAggregate(), "api-determinism")
+	require.NotEmpty(t, want)
+
+	batchesFor := func(ids []string) [][]string {
+		var batches [][]string
+		for i := 0; i < len(ids); i += batchSize {
+			end := i + batchSize
+			if end > len(ids) {
+				end = len(ids)
+			}
+			batches = append(batches, ids[i:end])
+		}
+		return batches
+	}
+	wantBatches := batchesFor(want)
+	require.Greater(t, len(wantBatches), 1, "input must span more than one batch to test batch boundaries")
+
+	for run := 1; run < runs; run++ {
+		got := idsFor(makeAggregate(), "api-determinism")
+		require.Equalf(t, want, got, "run %d produced a different row order; lock ordering is not deterministic", run)
+		require.Equalf(t, wantBatches, batchesFor(got), "run %d produced different batch boundaries", run)
+	}
+}

--- a/pumps/sql_test.go
+++ b/pumps/sql_test.go
@@ -2,12 +2,14 @@ package pumps
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
@@ -362,15 +364,29 @@ func TestSQLWriteUptimeDataAggregations(t *testing.T) {
 	}
 
 	assert.Len(t, dbRecords, 3)
-	assert.Equal(t, "url", dbRecords[0].Dimension)
-	assert.Equal(t, "url1", dbRecords[0].DimensionValue)
-	assert.Equal(t, 3, dbRecords[0].Code200)
-	assert.Equal(t, 2, dbRecords[0].Code500)
-	assert.Equal(t, 5, dbRecords[0].Hits)
-	assert.Equal(t, 3, dbRecords[0].Success)
-	assert.Equal(t, 2, dbRecords[0].ErrorTotal)
-	assert.Equal(t, 14.0, dbRecords[0].RequestTime)
-	assert.Equal(t, 70.0, dbRecords[0].TotalRequestTime)
+
+	// Find the row under test by dimension rather than by position. Find() has
+	// no ORDER BY, so the result order follows insertion order, and the pump
+	// sorts each batch by ID before upserting (TT-9424).
+	var urlRec *analytics.UptimeReportAggregateSQL
+	for i := range dbRecords {
+		if dbRecords[i].Dimension == "url" {
+			urlRec = &dbRecords[i]
+			break
+		}
+	}
+	if !assert.NotNil(t, urlRec, `expected a record with dimension "url"`) {
+		return
+	}
+
+	assert.Equal(t, "url1", urlRec.DimensionValue)
+	assert.Equal(t, 3, urlRec.Code200)
+	assert.Equal(t, 2, urlRec.Code500)
+	assert.Equal(t, 5, urlRec.Hits)
+	assert.Equal(t, 3, urlRec.Success)
+	assert.Equal(t, 2, urlRec.ErrorTotal)
+	assert.Equal(t, 14.0, urlRec.RequestTime)
+	assert.Equal(t, 70.0, urlRec.TotalRequestTime)
 }
 
 func TestDecodeRequestAndDecodeResponseSQL(t *testing.T) {
@@ -502,5 +518,52 @@ func TestBuildIndexName(t *testing.T) {
 				t.Errorf("buildIndexName(%s, %s) = %s; want %s", tt.indexBaseName, tt.tableName, result, tt.expected)
 			}
 		})
+	}
+}
+
+// TestSQLWriteUptimeData_SQLite exercises WriteUptimeData against in-memory SQLite, so it runs
+// everywhere - including the coverage CI job, which provisions no PostgreSQL and therefore
+// skips every Postgres-gated test in this package.
+//
+// Init() is deliberately not called: Dialect() has not supported sqlite since v1.12.0, so the
+// pump is built directly over the test database. WriteUptimeData does not migrate in the
+// non-sharded branch, so the table has to exist up front.
+//
+// Note this call mutates the package-level `table` variable declared in influx.go, which is
+// shared process-wide - a pre-existing issue recorded on TT-9424. That is why this test must
+// not be made parallel.
+func TestSQLWriteUptimeData_SQLite(t *testing.T) {
+	db := setupTestDBWithJSONTags(t)
+	require.NoError(t, db.Table(analytics.UptimeSQLTable).AutoMigrate(&analytics.UptimeReportAggregateSQL{}))
+
+	pmp := &SQLPump{IsUptime: true, db: db}
+	pmp.SQLConf = &SQLConf{BatchSize: 100}
+	pmp.log = log.WithField("prefix", SQLPrefix+"-uptime")
+
+	ts := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	records := make([]interface{}, 0, 4)
+	for i := 0; i < 4; i++ {
+		encoded, err := msgpack.Marshal(analytics.UptimeReportData{
+			OrgID:        "org1",
+			URL:          fmt.Sprintf("https://upstream.example/%02d", i),
+			APIID:        "api1",
+			ResponseCode: 200,
+			RequestTime:  10,
+			TimeStamp:    ts,
+		})
+		require.NoError(t, err)
+		records = append(records, string(encoded))
+	}
+
+	pmp.WriteUptimeData(records)
+
+	var recs []analytics.UptimeReportAggregateSQL
+	require.NoError(t, pmp.db.Table(analytics.UptimeSQLTable).Find(&recs).Error)
+
+	// One row per distinct URL plus the implicit "total" row.
+	assert.Len(t, recs, 5)
+	for _, rec := range recs {
+		assert.Equal(t, "org1", rec.OrgID)
+		assert.NotEmpty(t, rec.ID)
 	}
 }


### PR DESCRIPTION
Based on #1058, which was approved and merged prematurely as `eead02ed` before QA, so it had to be reverted by #1067 (`e43a3b8f`).


## What this contains

This is a single `git revert` of #1067's squash commit, so it restores **both** changes that #1058 carried:

- **The deadlock fix** — all four `sort.Slice(recs, ...)` sites (`pumps/sql_aggregate.go`, `pumps/graph_sql_aggregate.go`, `pumps/mcp_sql_aggregate.go`, `pumps/sql.go`), giving every replica the same row-lock acquisition order and preventing the circular waits behind `SQLSTATE 40P01`.
- **The flakey unit test fix** — `OmitIndexCreation: true` in `TestMCPSQLAggregatePump_WriteData`, which stops the background `CREATE INDEX CONCURRENTLY` goroutine from racing the subtest's `DROP TABLE` cleanup.

## Side benefit

`master` is currently red at `e43a3b8f`: `TestMCPSQLAggregatePump_WriteData/tracks_errors` fails at roughly 1 run in 3, because the revert took the `OmitIndexCreation` workaround out along with the production change. Merging this fixes that flakey test, since the fix rides along. 

## Verification

- Diff is the exact inverse of #1067: 8 files, **+689/−9**, recreating `pumps/sql_deadlock_ordering_test.go`.
- `git diff eead02ed HEAD -- pumps/` is **empty** — byte-identical to the tree that was already reviewed and approved on #1058.
- Branched off current `master`, so it includes `ac01deff` (GCP IAM auth) and the two Kinesis fixes that the original `TT-9424-sql-aggregate-deadlock` branch predates.
- `go build ./...` and `go test ./pumps/ -run 'TestSQL|TestMCPSQL' -count=1` pass locally.

## Note for reviewers

The `validate` (Jira linter) check will fail while TT-9424 sits in `Ready for Testing` — that status is not in the linter's accepted list. It is not a required check. Required checks are `Aggregated CI Status` and `Unit Tests & Linting`.

Full background, test methodology, and the four-call-site verification are on [TT-9424](https://tyktech.atlassian.net/browse/TT-9424).


[TT-9424]: https://tyktech.atlassian.net/browse/TT-9424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ