### PR TITLE
TT-17858 trigger CI status check on release-1.17 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1621,3 +1621,4 @@ You can run Tyk Pump in demo mode, which will generate fake analytics data and s
 - `--demo-records-per-hour=<RECORDS_PER_HOUR>` - Sets the number of records to generate per hour. The default value is a random number between 300 and 500.
 - `--demo-track-path` - Enables tracking of the request path in the demo data. Defaults to false (disabled). Note that setting `track_all_paths` to `true` in your Pump configuration will override this option.
 - `--demo-future-data` - By default, the demo data is generated for the past X days (configured in `demo-days` flag). This option will generate data for the next X days. Defaults to false (disabled).
+


### PR DESCRIPTION
## Summary
Trivial no-op change to trigger a real pull_request event against
`release-1.17`, so the `Aggregated CI Status` check (which only runs
on `pull_request`, per its workflow `if:` condition) actually
executes and passes on this branch's HEAD.

## Why
The branch's current HEAD was set by a direct bot push (gromit
template sync, "Auto generated from templates by gromit"), which
never triggers the pull_request-only aggregator job. Because the
repo's required-status-checks ruleset also enforces on branch
creation (`do_not_enforce_on_create: false`), attempting to create
`release-1.17.0` from this branch was blocked with:

> Required status check "Aggregated CI Status" is expected.

Merging this PR should get a real, passing status attached to HEAD,
unblocking the release-1.17.0 branch creation.
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17858" title="TT-17858" target="_blank">TT-17858</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | {Release Prep} Pump 1.17.0 |

Generated at: 2026-08-12 13:06:09

</details>

<!---TykTechnologies/jira-linter ends here-->
