### PR TITLE
TT-17858: Bump google.golang.org/grpc to v1.82.1 for GHSA-hrxh-6v49-42gf

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -182,7 +182,7 @@ require (
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7 // indirect
-	google.golang.org/grpc v1.82.0 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -712,8 +712,8 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.82.0 h1:vguDnZUPjE26w09A63VoxZPnvPjB5Riyc0mkXPFmAIU=
-google.golang.org/grpc v1.82.0/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=


### PR DESCRIPTION
## Description

Bumps the indirect dependency `google.golang.org/grpc` from `v1.82.0` to `v1.82.1`.

Only `go.mod` and `go.sum` change — no source changes required.

## Related Issue

TT-17858 (release prep for Pump 1.17.0)

Advisory: [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) — gRPC-Go: xDS RBAC and HTTP/2 Vulnerabilities
Dependabot alert: https://github.com/TykTechnologies/tyk-pump/security/dependabot/49

## Motivation and Context

A Trivy scan of `go.mod` reported a HIGH severity vulnerability in `google.golang.org/grpc v1.82.0`. `v1.82.1` is the fixed version. `grpc` is pulled in indirectly via `github.com/TykTechnologies/storage/kv/providers/gcp`.

### Note on the remaining Trivy finding

Trivy also reports `golang.org/x/crypto` GO-2026-5932 (severity UNKNOWN). This one is **not actionable** and is intentionally not addressed here:

- There is no fixed version — the advisory states that `x/crypto/openpgp` is unmaintained and unsafe by design, rather than describing a patchable defect.
- This repo does not use `openpgp`. `go mod why golang.org/x/crypto/openpgp` reports `main module does not need package`. `x/crypto` is required only for `pbkdf2`, via `segmentio/kafka-go/sasl/scram` -> `xdg/scram`.
- `govulncheck ./...` confirms 0 vulnerabilities are reachable from our code.

Trivy flags this at the module level rather than the package level, so it will continue to appear in scans. If a clean scan is a hard release gate, a follow-up could add a `.trivyignore` entry with the justification above.

## How This Has Been Tested

- `go build ./...` — passes
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `govulncheck ./...` — "No vulnerabilities found"; 0 vulnerabilities called by our code
- `trivy fs --scanners vuln go.mod` — re-run after the bump; the HIGH finding is gone, leaving only the unreachable `x/crypto` UNKNOWN described above

Note: the full test suite was not run locally, as this change touches only dependency versions. Deferring to CI for that.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side).
- [x] Make sure you are making a pull request against the **`master` branch** (left side).
- [ ] My change requires a change to the documentation.
- [x] Modules and vendor dependencies have been updated; ran `go mod tidy` (this repo does not vendor, so `go mod vendor` is not applicable)
- [ ] I have added tests to cover my changes. — not applicable, dependency bump only
- [ ] All new and existing tests passed. — deferring to CI; see testing notes above
- [x] Check your code additions will not fail linting checks:
  - [x] `go fmt -s`
  - [x] `go vet`

https://claude.ai/code/session_011faxZHWdBowx5WHDkdYAMt
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-17858" title="TT-17858" target="_blank">TT-17858</a>
</summary>

|         |    |
|---------|----|
| Status  | In Dev |
| Summary | {Release Prep} Pump 1.17.0 |

Generated at: 2026-08-12 19:15:27

</details>

<!---TykTechnologies/jira-linter ends here-->
