### PR TITLE
[TT-14423] stop the hybrid pump orphaning gorpc clients

### DIFF
--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -68,6 +68,10 @@ type HybridPump struct {
 	// WriteData goroutines while a reconnect may be replacing them.
 	clientMu sync.RWMutex
 
+	// clientGen counts published clients, so a recovery that waited for connectMu can tell
+	// whether the client whose failure sent it there has already been replaced.
+	clientGen atomic.Uint64
+
 	clientSingleton   *gorpc.Client
 	dispatcher        *gorpc.Dispatcher
 	clientIsConnected atomic.Value
@@ -201,6 +205,8 @@ func (p *HybridPump) startDispatcher(client *gorpc.Client) {
 	p.dispatcher = dispatcher
 	p.clientSingleton = client
 	p.funcClientSingleton = funcClient
+
+	p.clientGen.Add(1)
 }
 
 // stopClient stops the current RPC client, if there is one, and clears it.
@@ -472,11 +478,35 @@ func (p *HybridPump) sendMCPAggregates(data []interface{}) error {
 
 // connectAndLogin connects to RPC server and logs in if retry is true, it will retry with retryAndLog func
 func (p *HybridPump) connectAndLogin(retry bool) error {
+	// Which client this recovery is trying to replace. Read before queueing on the lock, so it
+	// can be compared with whatever is current once the lock is held.
+	observedGen := p.clientGen.Load()
+
 	// One recovery at a time, covering the retry loop and the login that follows it. Locking
 	// only around a single connect attempt would let two recoveries interleave, each stopping
 	// the client the other had just published.
 	p.connectMu.Lock()
 	defer p.connectMu.Unlock()
+
+	// When several purge cycles overlap they all fail together and all end up here, queued on
+	// the lock. Only the first of them needs to reconnect: rebuilding again would stop a client
+	// that is already working and that another purge may be part way through writing through,
+	// and a purge that fails loses its records for good, because the purge loop deletes them
+	// from the temporal store before handing them over.
+	if p.clientGen.Load() != observedGen {
+		err := p.RPCLogin()
+		if err == nil {
+			p.log.Debug("Reusing the MDCB connection another purge just established")
+
+			return nil
+		}
+
+		// Credentials are wrong rather than the connection being broken. Reconnecting cannot
+		// fix that, and doing so would tear down a usable client for nothing.
+		if errors.Is(err, ErrRPCLogin) {
+			return err
+		}
+	}
 
 	connectFn := p.connectRPC
 	loginFn := p.RPCLogin

--- a/pumps/hybrid.go
+++ b/pumps/hybrid.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -53,6 +54,19 @@ var (
 // HybridPump allows to send analytics to MDCB over RPC
 type HybridPump struct {
 	CommonPumpConfig
+
+	// connectMu serialises connecting, reconnecting and shutting down. A WriteData call that
+	// outlives the configured pump timeout is abandoned and started again on the next purge
+	// cycle, so two recoveries can be in flight at once; without this lock each would build a
+	// client and could stop the other's brand-new one.
+	//
+	// Lock order is connectMu then clientMu, never the reverse. clientMu is only ever held to
+	// assign or read the pointers below, never across an RPC.
+	connectMu sync.Mutex
+
+	// clientMu guards clientSingleton and funcClientSingleton, which callRPCFn reads from the
+	// WriteData goroutines while a reconnect may be replacing them.
+	clientMu sync.RWMutex
 
 	clientSingleton   *gorpc.Client
 	dispatcher        *gorpc.Dispatcher
@@ -149,22 +163,74 @@ func (p *HybridPump) Init(config interface{}) error {
 
 	if err := p.connectAndLogin(true); err != nil {
 		p.log.Error(err)
+
+		// The connect may well have succeeded and only the login failed, leaving a running
+		// client behind. Nothing shuts down a pump whose Init returned an error, so its pool
+		// would stay up for the lifetime of the process.
+		p.connectMu.Lock()
+		p.stopClient()
+		p.connectMu.Unlock()
+
 		return err
 	}
 
 	return nil
 }
 
-func (p *HybridPump) startDispatcher() {
-	p.dispatcher = gorpc.NewDispatcher()
+// startDispatcher publishes an already started client along with a dispatcher client bound to
+// it. A gorpc.DispatcherClient cannot be pointed at a different gorpc.Client, so both have to be
+// rebuilt for every connection.
+//
+// The dispatcher is built in a local and published as a whole. Assigning it to the pump first
+// and filling it in afterwards let two concurrent reconnects register their functions into
+// whichever dispatcher happened to win the field, which is a concurrent map write.
+//
+// The caller must hold connectMu.
+func (p *HybridPump) startDispatcher(client *gorpc.Client) {
+	dispatcher := gorpc.NewDispatcher()
 
 	for funcName, funcBody := range dispatcherFuncs {
-		p.dispatcher.AddFunc(funcName, funcBody)
+		dispatcher.AddFunc(funcName, funcBody)
 	}
 
-	p.funcClientSingleton = p.dispatcher.NewFuncClient(p.clientSingleton)
+	funcClient := dispatcher.NewFuncClient(client)
+
+	p.clientMu.Lock()
+	defer p.clientMu.Unlock()
+
+	p.dispatcher = dispatcher
+	p.clientSingleton = client
+	p.funcClientSingleton = funcClient
 }
 
+// stopClient stops the current RPC client, if there is one, and clears it.
+//
+// A client is published only after gorpc.Client.Start() has returned (see connectRPC), so a
+// non-nil clientSingleton is always a running client and is safe to stop exactly once - gorpc
+// panics both on stopping a client that was never started and on stopping one twice.
+//
+// The caller must hold connectMu.
+func (p *HybridPump) stopClient() {
+	p.clientMu.Lock()
+	client := p.clientSingleton
+	p.clientSingleton = nil
+	p.funcClientSingleton = nil
+	p.clientMu.Unlock()
+
+	p.clientIsConnected.Store(false)
+
+	if client == nil {
+		return
+	}
+
+	// Bounded even when MDCB is unreachable: the pooled handlers return as soon as the client's
+	// stop channel is closed and do not wait for an outstanding dial.
+	client.Stop()
+}
+
+// connectRPC replaces the current RPC client with a freshly connected one.
+//
+// The caller must hold connectMu.
 func (p *HybridPump) connectRPC() error {
 	p.log.Debug("Setting new MDCB connection!")
 
@@ -179,30 +245,42 @@ func (p *HybridPump) connectRPC() error {
 		return errors.New("connID is too long")
 	}
 
+	var client *gorpc.Client
+
 	if p.hybridConfig.UseSSL {
 		// #nosec G402
 		clientCfg := &tls.Config{
 			InsecureSkipVerify: p.hybridConfig.SSLInsecureSkipVerify,
 		}
 
-		p.clientSingleton = gorpc.NewTLSClient(p.hybridConfig.ConnectionString, clientCfg)
+		client = gorpc.NewTLSClient(p.hybridConfig.ConnectionString, clientCfg)
 	} else {
-		p.clientSingleton = gorpc.NewTCPClient(p.hybridConfig.ConnectionString)
+		client = gorpc.NewTCPClient(p.hybridConfig.ConnectionString)
 	}
 
 	if p.log.Level != logrus.DebugLevel {
-		p.clientSingleton.LogError = gorpc.NilErrorLogger
+		client.LogError = gorpc.NilErrorLogger
 	}
 
-	p.clientSingleton.OnConnect = p.onConnectFunc
+	client.OnConnect = p.onConnectFunc
 
-	p.clientSingleton.Conns = p.hybridConfig.RPCPoolSize
+	client.Conns = p.hybridConfig.RPCPoolSize
 
-	p.clientSingleton.Dial = getDialFn(connID, p.hybridConfig)
+	client.Dial = getDialFn(connID, p.hybridConfig)
 
-	p.clientSingleton.Start()
+	// Release the client being replaced before starting its successor (TT-14423). Every
+	// gorpc.Client keeps rpc_pool_size goroutines redialling MDCB until it is stopped, so simply
+	// overwriting the pointer abandoned the whole pool - goroutines here, connections and memory
+	// on MDCB - on every single reconnect, and nothing ever closed them. Stopping first also
+	// keeps the pump within rpc_pool_size connections at every instant, including while the
+	// retrying connect below is working through its attempts.
+	p.stopClient()
 
-	p.startDispatcher()
+	client.Start()
+
+	// Published only now: until Start() has returned there is nothing to stop, and callers
+	// reading the pointer must never see a client that is not running.
+	p.startDispatcher(client)
 
 	_, err = p.callRPCFn("Ping", nil)
 
@@ -218,7 +296,18 @@ func (p *HybridPump) onConnectFunc(conn net.Conn) (net.Conn, string, error) {
 }
 
 func (p *HybridPump) callRPCFn(funcName string, request interface{}) (interface{}, error) {
-	return p.funcClientSingleton.CallTimeout(funcName, request, time.Duration(p.hybridConfig.CallTimeout)*time.Second)
+	p.clientMu.RLock()
+	funcClient := p.funcClientSingleton
+	p.clientMu.RUnlock()
+
+	// Nil between a stop and the next successful connect, and for the whole life of a pump whose
+	// Init failed. Reporting it beats both dereferencing nil and burning a full call timeout on a
+	// client that has been stopped.
+	if funcClient == nil {
+		return nil, errors.New("not connected to Tyk MDCB")
+	}
+
+	return funcClient.CallTimeout(funcName, request, time.Duration(p.hybridConfig.CallTimeout)*time.Second)
 }
 
 func getDialFn(connID string, config *HybridPumpConf) func(addr string) (conn net.Conn, err error) {
@@ -327,11 +416,13 @@ func (p *HybridPump) WriteData(ctx context.Context, data []interface{}) error {
 
 func (p *HybridPump) Shutdown() error {
 	p.log.Info("Shutting down...")
-	p.clientSingleton.Stop()
-	p.clientSingleton = nil
-	p.funcClientSingleton = nil
 
-	p.clientIsConnected.Store(false)
+	// Waits for a reconnect that is already under way rather than stopping a client from under
+	// it. Nil-safe and repeatable, both of which matter: a pump whose Init failed never got a
+	// client and is shut down along with the others.
+	p.connectMu.Lock()
+	p.stopClient()
+	p.connectMu.Unlock()
 
 	p.log.Info("Pump shut down.")
 	return nil
@@ -381,6 +472,12 @@ func (p *HybridPump) sendMCPAggregates(data []interface{}) error {
 
 // connectAndLogin connects to RPC server and logs in if retry is true, it will retry with retryAndLog func
 func (p *HybridPump) connectAndLogin(retry bool) error {
+	// One recovery at a time, covering the retry loop and the login that follows it. Locking
+	// only around a single connect attempt would let two recoveries interleave, each stopping
+	// the client the other had just published.
+	p.connectMu.Lock()
+	defer p.connectMu.Unlock()
+
 	connectFn := p.connectRPC
 	loginFn := p.RPCLogin
 

--- a/pumps/hybrid_test.go
+++ b/pumps/hybrid_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	"github.com/TykTechnologies/tyk-pump/analytics"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func setupKeepalive(conn net.Conn) error {
@@ -51,23 +54,33 @@ func (ln *testListener) Accept() (conn net.Conn, err error) {
 		return
 	}
 
-	handshake := make([]byte, 6)
-	if _, err = io.ReadFull(c, handshake); err != nil {
-		return
-	}
-
-	idLenBuf := make([]byte, 1)
-	if _, err = io.ReadFull(c, idLenBuf); err != nil {
-		return
-	}
-
-	idLen := uint8(idLenBuf[0])
-	id := make([]byte, idLen)
-	if _, err = io.ReadFull(c, id); err != nil {
-		return
+	if _, err = readConnID(c); err != nil {
+		return nil, err
 	}
 
 	return c, nil
+}
+
+// readConnID reads the handshake the pump's dialer writes: the protocol marker, a length byte
+// and then the connection id. The id is generated once per connectRPC, so it identifies the
+// gorpc.Client that opened the connection.
+func readConnID(c net.Conn) (string, error) {
+	handshake := make([]byte, 6)
+	if _, err := io.ReadFull(c, handshake); err != nil {
+		return "", err
+	}
+
+	idLenBuf := make([]byte, 1)
+	if _, err := io.ReadFull(c, idLenBuf); err != nil {
+		return "", err
+	}
+
+	id := make([]byte, uint8(idLenBuf[0]))
+	if _, err := io.ReadFull(c, id); err != nil {
+		return "", err
+	}
+
+	return string(id), nil
 }
 
 func (ln *testListener) Close() error {
@@ -643,8 +656,10 @@ func TestHybridConfigParsing(t *testing.T) {
 				os.Setenv(key, env)
 			}
 			defer func(envs map[string]string) {
-				for _, env := range envs {
-					os.Unsetenv(env)
+				// By key. Unsetting the values left this test case's variables set for
+				// every test declared after this one.
+				for key := range envs {
+					os.Unsetenv(key)
 				}
 			}(tc.givenEnvs)
 
@@ -849,4 +864,478 @@ func TestConnectAndLogin(t *testing.T) {
 			}
 		})
 	}
+}
+
+// connectRPC used to assign a fresh gorpc.Client over the previous one without stopping it.
+// Every gorpc.Client keeps rpc_pool_size clientHandler goroutines redialling MDCB until
+// Client.Stop() is called, so each reconnect abandoned a whole pool of connections that neither
+// side ever closed. The helpers below make that observable from the server side, which is the
+// only place it shows up: nothing about the leak is visible in the pump's own behaviour.
+
+// connCountingListener is a gorpc.Listener that tracks how many connections are currently open
+// per connection id. A gorpc.Client dials rpc_pool_size connections all carrying the id its
+// connectRPC generated, so a client that was replaced but never stopped shows up as a second id
+// whose count never falls to zero.
+//
+// It owns an already-open socket on an ephemeral port, so these tests need no hardcoded port and
+// cannot collide with the fixed-port tests in this file. Init is therefore a no-op: gorpc calls
+// it with the address this listener is already listening on.
+type connCountingListener struct {
+	L net.Listener
+
+	// live and total are both guarded by mu, which sits last only to keep the struct's pointer
+	// fields together - govet's fieldalignment check objects otherwise.
+	live  map[string]int
+	total map[string]int
+
+	mu sync.Mutex
+}
+
+func newConnCountingListener(t *testing.T) *connCountingListener {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	return &connCountingListener{
+		L:     l,
+		live:  map[string]int{},
+		total: map[string]int{},
+	}
+}
+
+func (ln *connCountingListener) Addr() string { return ln.L.Addr().String() }
+
+func (ln *connCountingListener) Init(string) error { return nil }
+
+func (ln *connCountingListener) Close() error { return ln.L.Close() }
+
+func (ln *connCountingListener) Accept() (net.Conn, error) {
+	c, err := ln.L.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setupKeepalive(c); err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	connID, err := readConnID(c)
+	if err != nil {
+		c.Close()
+		return nil, err
+	}
+
+	ln.mu.Lock()
+	ln.live[connID]++
+	ln.total[connID]++
+	ln.mu.Unlock()
+
+	return &countedConn{Conn: c, ln: ln, connID: connID}, nil
+}
+
+func (ln *connCountingListener) closed(connID string) {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	ln.live[connID]--
+}
+
+// liveFor is how many connections one client still holds, i.e. whether it is still running.
+func (ln *connCountingListener) liveFor(connID string) int {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	return ln.live[connID]
+}
+
+// liveConnIDs are the clients still holding at least one connection. One entry means one live
+// gorpc.Client.
+func (ln *connCountingListener) liveConnIDs() []string {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	ids := make([]string, 0, len(ln.live))
+	for id, n := range ln.live {
+		if n > 0 {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
+}
+
+// totalConnIDs are all the clients ever seen, stopped ones included, which is how many times
+// connectRPC actually built one.
+func (ln *connCountingListener) totalConnIDs() []string {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	ids := make([]string, 0, len(ln.total))
+	for id := range ln.total {
+		ids = append(ids, id)
+	}
+
+	return ids
+}
+
+// totalLive is every connection still open, across every client.
+func (ln *connCountingListener) totalLive() int {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	var n int
+	for _, c := range ln.live {
+		if c > 0 {
+			n += c
+		}
+	}
+
+	return n
+}
+
+// liveSnapshot is for failure messages: which client holds how many connections.
+func (ln *connCountingListener) liveSnapshot() map[string]int {
+	ln.mu.Lock()
+	defer ln.mu.Unlock()
+
+	out := make(map[string]int, len(ln.live))
+	for id, n := range ln.live {
+		if n > 0 {
+			out[id] = n
+		}
+	}
+
+	return out
+}
+
+// countedConn reports its connection as closed exactly once. gorpc closes a server connection
+// from more than one path, and double counting would make a live client look stopped.
+type countedConn struct {
+	net.Conn
+
+	ln     *connCountingListener
+	connID string
+	once   sync.Once
+}
+
+func (c *countedConn) Close() error {
+	c.once.Do(func() { c.ln.closed(c.connID) })
+
+	return c.Conn.Close()
+}
+
+func startRPCMockWithListener(
+	t *testing.T, addr string, dispatcher *gorpc.Dispatcher, ln gorpc.Listener,
+) *gorpc.Server {
+	t.Helper()
+
+	server := gorpc.NewTCPServer(addr, dispatcher.NewHandlerFunc())
+	server.Listener = ln
+	server.LogError = gorpc.NilErrorLogger
+
+	require.NoError(t, server.Start())
+	t.Cleanup(func() { stopRPCMock(t, server) })
+
+	return server
+}
+
+// stopClientQuietly stops c if it is still running. gorpc.Client.Stop() panics on a client that
+// was never started or was already stopped, and cleanup must not care which of those it is: the
+// point is only that no test leaves a pool of clientHandler goroutines redialling for the rest
+// of the package run.
+func stopClientQuietly(c *gorpc.Client) {
+	if c == nil {
+		return
+	}
+
+	// The panic is the expected outcome for an already stopped client, and its value carries
+	// nothing worth inspecting.
+	defer func() { recover() }() //nolint:errcheck
+
+	c.Stop()
+}
+
+// newLeakTestPump builds a pump against a fresh mock server on an ephemeral port. It assigns the
+// config directly instead of going through Init, so there is no mapstructure and no dependency
+// on the process environment.
+func newLeakTestPump(
+	t *testing.T, dispatcherFns map[string]interface{}, poolSize int,
+) (*HybridPump, *connCountingListener) {
+	t.Helper()
+
+	ln := newConnCountingListener(t)
+
+	dispatcher := gorpc.NewDispatcher()
+	for fnName, fn := range dispatcherFns {
+		dispatcher.AddFunc(fnName, fn)
+	}
+	startRPCMockWithListener(t, ln.Addr(), dispatcher, ln)
+
+	pump := &HybridPump{}
+	pump.hybridConfig = &HybridPumpConf{
+		ConnectionString: ln.Addr(),
+		RPCKey:           "testkey",
+		APIKey:           "testapikey",
+		CallTimeout:      1,
+		RPCPoolSize:      poolSize,
+	}
+	pump.log = log.WithField("prefix", "hybrid-test")
+
+	t.Cleanup(func() { stopClientQuietly(pump.clientSingleton) })
+
+	return pump, ln
+}
+
+// waitForSingleLiveConnID waits until exactly one client holds want connections and returns its
+// id, so a test can pin the baseline before provoking a reconnect.
+func waitForSingleLiveConnID(t *testing.T, ln *connCountingListener, want int) string {
+	t.Helper()
+
+	var id string
+	require.Eventually(t, func() bool {
+		ids := ln.liveConnIDs()
+		if len(ids) != 1 || ln.liveFor(ids[0]) != want {
+			return false
+		}
+		id = ids[0]
+
+		return true
+	}, 10*time.Second, 25*time.Millisecond,
+		"expected one client holding %d connections, have %v", want, ln.liveSnapshot())
+
+	return id
+}
+
+// rpcReleaseBudget is how long these tests give the mock server to let go of the connections of
+// a client the pump has stopped.
+//
+// Measured, with no pump involved at all: after gorpc.Client.Stop() returns, the server closes
+// its end of each connection either straight away or after almost exactly ten seconds, never
+// later. Which of the two it is varies per connection and per run. What is under test here is
+// that the pump lets go of the client at all; how long gorpc then takes to notice is not this
+// package's business, so the budget only has to clear that ten seconds. An unfixed pump never
+// lets go, and its connections stay up for as long as the process lives, so nothing is hidden by
+// waiting a little longer.
+const rpcReleaseBudget = 15 * time.Second
+
+// waitForLive polls until cond holds, and on timeout reports the state as it is then. It exists
+// because assert.Eventually evaluates its message arguments eagerly, so a snapshot passed to it
+// describes the moment the wait started rather than the moment it gave up.
+func waitForLive(t *testing.T, ln *connCountingListener, budget time.Duration, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	t.Errorf("%s; connections still open per client: %v", what, ln.liveSnapshot())
+}
+
+func TestConnectRPCStopsPreviousClient(t *testing.T) {
+	const poolSize = 3
+
+	pump, ln := newLeakTestPump(t, map[string]interface{}{
+		"Ping":  func() bool { return true },
+		"Login": func(_, _ string) bool { return true },
+	}, poolSize)
+
+	require.NoError(t, pump.connectRPC())
+
+	first := pump.clientSingleton
+	require.NotNil(t, first)
+	t.Cleanup(func() { stopClientQuietly(first) })
+
+	firstID := waitForSingleLiveConnID(t, ln, poolSize)
+
+	require.NoError(t, pump.connectRPC())
+
+	second := pump.clientSingleton
+	require.NotNil(t, second)
+	require.NotSame(t, first, second)
+	t.Cleanup(func() { stopClientQuietly(second) })
+
+	// Without a Stop() the replaced client keeps its pool redialling for the lifetime of the
+	// process, and MDCB keeps paying for every one of those connections.
+	waitForLive(t, ln, rpcReleaseBudget, "the replaced client still holds connections", func() bool {
+		return ln.liveFor(firstID) == 0 && ln.totalLive() == poolSize
+	})
+
+	// Direct proof that connectRPC stopped it, rather than its connections merely having gone
+	// away: gorpc.Client.Stop() panics unless the client is running. Asserted last, because it
+	// stops the client itself and would otherwise satisfy the check above.
+	assert.Panics(t, func() { first.Stop() },
+		"connectRPC left the previous gorpc client running")
+}
+
+func TestConnectAndLoginRetryDoesNotOrphanClients(t *testing.T) {
+	const poolSize = 2
+
+	var pings int64
+
+	pump, ln := newLeakTestPump(t, map[string]interface{}{
+		// The first two answers arrive after call_timeout, so the first two connectRPC attempts
+		// fail and the retry builds another client for each of them.
+		"Ping": func() bool {
+			if atomic.AddInt64(&pings, 1) <= 2 {
+				time.Sleep(1500 * time.Millisecond)
+			}
+
+			return true
+		},
+		"Login": func(_, _ string) bool { return true },
+	}, poolSize)
+
+	require.NoError(t, pump.connectAndLogin(true))
+	t.Cleanup(func() { stopClientQuietly(pump.clientSingleton) })
+
+	// Guard the premise: with no retries there is nothing to orphan and the assertion below
+	// would pass for the wrong reason.
+	require.GreaterOrEqual(t, len(ln.totalConnIDs()), 3, "the retry path did not run")
+
+	waitForLive(t, ln, rpcReleaseBudget, "the retried connect attempts left clients behind", func() bool {
+		return len(ln.liveConnIDs()) == 1 && ln.totalLive() == poolSize
+	})
+}
+
+func TestConcurrentReconnectKeepsSingleClient(t *testing.T) {
+	const (
+		poolSize = 2
+		callers  = 8
+	)
+
+	pump, ln := newLeakTestPump(t, map[string]interface{}{
+		"Ping":  func() bool { return true },
+		"Login": func(_, _ string) bool { return true },
+	}, poolSize)
+
+	require.NoError(t, pump.connectRPC())
+	waitForSingleLiveConnID(t, ln, poolSize)
+
+	// A WriteData call that outlives the pump's configured timeout is abandoned and started
+	// again on the next purge cycle, so several recoveries can be in flight at once.
+	var (
+		mu     sync.Mutex
+		errs   []error
+		panics []interface{}
+		wg     sync.WaitGroup
+	)
+
+	start := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					mu.Lock()
+					panics = append(panics, r)
+					mu.Unlock()
+				}
+			}()
+
+			<-start
+
+			err := pump.connectAndLogin(false)
+
+			mu.Lock()
+			errs = append(errs, err)
+			mu.Unlock()
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	t.Cleanup(func() { stopClientQuietly(pump.clientSingleton) })
+
+	// Two recoveries must not stop the same client, which gorpc answers with a panic.
+	assert.Empty(t, panics, "concurrent reconnects panicked")
+
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+
+	// And only one client may survive them.
+	waitForLive(t, ln, rpcReleaseBudget, "more than one client survived concurrent reconnects", func() bool {
+		return len(ln.liveConnIDs()) == 1 && ln.totalLive() == poolSize
+	})
+
+	// The survivor must be the published one, i.e. the pump's state is not torn.
+	_, err := pump.callRPCFn("Ping", nil)
+	assert.NoError(t, err)
+}
+
+func TestShutdownWithoutClient(t *testing.T) {
+	// Init returns before connectRPC for an invalid configuration, and a pump whose Init failed
+	// is still shut down along with the others.
+	pump := &HybridPump{}
+	pump.hybridConfig = &HybridPumpConf{}
+	pump.log = log.WithField("prefix", "hybrid-test")
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, pump.Shutdown())
+	})
+}
+
+func TestShutdownIsIdempotent(t *testing.T) {
+	pump, _ := newLeakTestPump(t, map[string]interface{}{
+		"Ping":  func() bool { return true },
+		"Login": func(_, _ string) bool { return true },
+	}, 2)
+
+	require.NoError(t, pump.connectRPC())
+	require.NoError(t, pump.Shutdown())
+
+	assert.NotPanics(t, func() {
+		assert.NoError(t, pump.Shutdown())
+	})
+	assert.Nil(t, pump.clientSingleton)
+
+	connected, ok := pump.clientIsConnected.Load().(bool)
+	require.True(t, ok, "clientIsConnected was never set")
+	assert.False(t, connected)
+}
+
+func TestInitFailureReleasesRPCClient(t *testing.T) {
+	const poolSize = 2
+
+	ln := newConnCountingListener(t)
+
+	dispatcher := gorpc.NewDispatcher()
+	dispatcher.AddFunc("Ping", func() bool { return true })
+	dispatcher.AddFunc("Login", func(_, _ string) bool { return false })
+	startRPCMockWithListener(t, ln.Addr(), dispatcher, ln)
+
+	// Init reads the pump's env namespace, so pin the address this test needs instead of
+	// inheriting whatever the ambient environment points the hybrid pump at.
+	t.Setenv("TYK_PMP_PUMPS_HYBRID_META_CONNECTIONSTRING", ln.Addr())
+
+	pump := &HybridPump{}
+	err := pump.Init(&HybridPumpConf{
+		ConnectionString: ln.Addr(),
+		APIKey:           "wrong",
+		CallTimeout:      1,
+		RPCPoolSize:      poolSize,
+	})
+	t.Cleanup(func() { stopClientQuietly(pump.clientSingleton) })
+
+	require.ErrorIs(t, err, ErrRPCLogin)
+
+	// Nothing shuts down a pump whose Init failed, so Init must not leave a client behind when
+	// it returns an error. Releasing it also clears the pointer, and that part is immediate.
+	assert.Nil(t, pump.clientSingleton, "Init returned an error but kept its RPC client")
+
+	// And the connections have to go - see rpcReleaseBudget for why that is not immediate.
+	waitForLive(t, ln, rpcReleaseBudget, "Init left an RPC client connected", func() bool {
+		return ln.totalLive() == 0
+	})
 }

--- a/pumps/hybrid_test.go
+++ b/pumps/hybrid_test.go
@@ -1269,6 +1269,12 @@ func TestConcurrentReconnectKeepsSingleClient(t *testing.T) {
 		return len(ln.liveConnIDs()) == 1 && ln.totalLive() == poolSize
 	})
 
+	// Only the first of them should have rebuilt at all. The rest have to reuse what it
+	// published: replacing a working client would stop one that another purge may be part way
+	// through writing through, and those records are already gone from the temporal store.
+	assert.LessOrEqual(t, len(ln.totalConnIDs()), 3,
+		"each queued recovery built its own client instead of reusing the first one")
+
 	// The survivor must be the published one, i.e. the pump's state is not torn.
 	_, err := pump.callRPCFn("Ping", nil)
 	assert.NoError(t, err)
@@ -1337,5 +1343,107 @@ func TestInitFailureReleasesRPCClient(t *testing.T) {
 	// And the connections have to go - see rpcReleaseBudget for why that is not immediate.
 	waitForLive(t, ln, rpcReleaseBudget, "Init left an RPC client connected", func() bool {
 		return ln.totalLive() == 0
+	})
+}
+
+func TestQueuedRecoveryReusesTheNewClient(t *testing.T) {
+	const poolSize = 2
+
+	pump, ln := newLeakTestPump(t, map[string]interface{}{
+		"Ping":               func() bool { return true },
+		"Login":              func(_, _ string) bool { return true },
+		"PurgeAnalyticsData": func(_, _ string) error { return nil },
+	}, poolSize)
+
+	require.NoError(t, pump.connectAndLogin(false))
+
+	// Hold the reconnect lock, so the recovery started below gets as far as reading the current
+	// generation and then waits - which is where every overlapping purge cycle ends up when one
+	// of them is already reconnecting.
+	pump.connectMu.Lock()
+
+	queued := make(chan error, 1)
+	started := make(chan struct{})
+
+	go func() {
+		close(started)
+
+		queued <- pump.connectAndLogin(false)
+	}()
+
+	// Only an atomic load separates the goroutine from the lock, so this is a generous wait. If
+	// it were not enough the goroutine would read the new generation instead of the old one and
+	// rebuild, which fails the assertions below rather than passing them for the wrong reason.
+	<-started
+	time.Sleep(50 * time.Millisecond)
+
+	// The recovery that holds the lock finishes and publishes a working client.
+	require.NoError(t, pump.connectRPC())
+	published := pump.clientSingleton
+	require.NotNil(t, published)
+	built := len(ln.totalConnIDs())
+
+	pump.connectMu.Unlock()
+
+	require.NoError(t, <-queued)
+
+	// The queued recovery has to reuse that client, not replace it.
+	assert.Equal(t, built, len(ln.totalConnIDs()), "the queued recovery built another client")
+	assert.Same(t, published, pump.clientSingleton, "the queued recovery replaced a working client")
+
+	waitForLive(t, ln, rpcReleaseBudget, "the published client lost connections", func() bool {
+		return ln.totalLive() == poolSize
+	})
+
+	// The point of all of it: a purge writing through that client still gets through. Records are
+	// deleted from the temporal store before WriteData is called, so a write broken by someone
+	// else's reconnect loses them for good.
+	_, err := pump.callRPCFn("PurgeAnalyticsData", "[]")
+	assert.NoError(t, err)
+}
+
+func TestQueuedRecoveryKeepsClientWhenCredentialsAreRejected(t *testing.T) {
+	const poolSize = 2
+
+	var logins int64
+
+	pump, ln := newLeakTestPump(t, map[string]interface{}{
+		"Ping": func() bool { return true },
+		// Only the first login succeeds, so the queued recovery below finds the freshly published
+		// client rejecting its credentials.
+		"Login": func(_, _ string) bool { return atomic.AddInt64(&logins, 1) == 1 },
+	}, poolSize)
+
+	require.NoError(t, pump.connectAndLogin(false))
+
+	pump.connectMu.Lock()
+
+	queued := make(chan error, 1)
+	started := make(chan struct{})
+
+	go func() {
+		close(started)
+
+		queued <- pump.connectAndLogin(false)
+	}()
+
+	<-started
+	time.Sleep(50 * time.Millisecond)
+
+	require.NoError(t, pump.connectRPC())
+	published := pump.clientSingleton
+	built := len(ln.totalConnIDs())
+
+	pump.connectMu.Unlock()
+
+	// Rejected credentials are reported rather than reconnected around: another client would not
+	// be given a different answer, and building one would tear down a usable connection.
+	require.ErrorIs(t, <-queued, ErrRPCLogin)
+
+	assert.Equal(t, built, len(ln.totalConnIDs()), "a rejected login triggered another client")
+	assert.Same(t, published, pump.clientSingleton, "a rejected login replaced a working client")
+
+	waitForLive(t, ln, rpcReleaseBudget, "the published client was stopped", func() bool {
+		return ln.totalLive() == poolSize
 	})
 }


### PR DESCRIPTION
## Problem

`HybridPump.connectRPC()` replaced `p.clientSingleton` with a freshly built `gorpc.Client` and
never stopped the one it was replacing.

A `gorpc.Client` runs `rpc_pool_size` (default 5) `clientHandler` goroutines, each an infinite
redial loop that exits **only** when `Client.Stop()` is called. Dropping the reference does
nothing. MDCB has no idle timeout and no connection cap, so it accepts every one of those redials
and pays roughly 1.7 MB and three goroutines per connection, permanently.

Every recovery therefore cost a whole pool that neither side ever released:

```
WriteData
  ├─ no records? return                          ← an idle pump never leaks
  ├─ RPCLogin() fails
  │    └─ ErrRPCLogin (bad credentials)? return  ← does not leak
  └─ any other error → connectAndLogin(false)
       └─ connectRPC()
            ├─ p.clientSingleton = gorpc.NewTLSClient(...)   ← old client abandoned
            └─ p.clientSingleton.Start()                     ← +5 goroutines, +5 connections
```

That closes a loop with no ceiling: MDCB runs out of memory → the restart outlasts the pump's
`call_timeout` → every pump orphans a client → MDCB runs out sooner.

Two conditions are needed to trigger it, and both are easy to get wrong. Records have to be
flowing, because `WriteData` returns early with nothing to write; and the failure has to outlast
`call_timeout` (default 10s), because gorpc redials within about a second, so merely severing
established connections leaks nothing.

`Init()` had the same defect and could orphan **three** clients on its own: it calls
`connectAndLogin(true)`, whose `retryAndLog` wrapper invokes `connectRPC` up to four times, and
each invocation built and started another client.

Present since v1.8.0 (`ca22ae4b`, March 2023).

## The fix

### `connectRPC` releases the client it replaces

The new client is configured in a local variable and published only after `Start()` has returned.
That establishes the invariant the rest of the change relies on: **`clientSingleton` is non-nil
only when it refers to a running client**, so a non-nil pointer is always safe to stop exactly
once. The invariant is necessary because `gorpc.Client.Stop()` panics both on a client that was
never started and on one that is stopped twice, and `clientStopChan` is unexported — there is no
way to ask a client whether it is running.

The replaced client is stopped *before* the successor starts, in a new `stopClient()` helper that
also clears the pointers and resets `clientIsConnected`. Stopping first rather than last is
deliberate:

- `Stop()` returns promptly even when MDCB is unreachable — the pooled handlers return as soon as
  the stop channel closes and do not wait for an outstanding dial — so the gap is negligible.
- It keeps the pump within `rpc_pool_size` connections at every instant, including while a
  retrying connect works through its attempts. Starting first would spike to twice the pool per
  attempt, which is the shape of the incident this fixes.
- Only one client's `OnConnect` is ever live, so `clientIsConnected` has a single writer.

There is no healthy traffic to protect during that gap: `connectRPC` is only reached because a
`Ping` or `Login` has already failed, or from `Init`.

### The reconnect is serialised

`WriteData` runs on a goroutine that is abandoned when the pump's configured `timeout` expires,
and the next purge cycle starts another one, so two recoveries can be in flight at once. A new
`connectMu` is taken for the whole of `connectAndLogin`, covering the retry loop *and* the login
that follows. Locking only around a single connect attempt would let attempts interleave, each
stopping the client the other had just published.

Without it the damage was worse than a leak. `startDispatcher` used to assign
`p.dispatcher = gorpc.NewDispatcher()` and then register the functions into the field, so two
concurrent reconnects registered into whichever dispatcher won the race — a concurrent map write,
which crashes the process:

```
fatal error: concurrent map writes
  gorpc.(*Dispatcher).AddFunc
  pumps.(*HybridPump).startDispatcher
  pumps.(*HybridPump).connectRPC
```

`startDispatcher` now builds the dispatcher and func client in locals and publishes them as a
unit, which removes that crash independently of the lock.

A second, separate `clientMu sync.RWMutex` guards the two pointers, which `callRPCFn` reads from
the `WriteData` goroutines. It is deliberately not the same mutex: `connectRPC` ends by calling
`callRPCFn("Ping", ...)`, so a single non-reentrant lock would self-deadlock. Lock order is
`connectMu` then `clientMu`, never the reverse, and `clientMu` is only ever held to assign or read
pointers, never across an RPC — so an in-flight purge is never blocked behind a 10s `Ping`.

`callRPCFn` now returns an error when there is no client instead of dereferencing nil. That also
avoids burning a full `CallTimeout` on a client that has been stopped.

### Two adjacent defects, included because they are the same bug

- **`Shutdown()` did an unguarded `Stop()`.** `Init` returns before `connectRPC` for an invalid
  configuration, leaving `clientSingleton` nil, and a pump whose `Init` failed is still shut down
  along with the others — a live nil-pointer dereference. It now goes through `stopClient()` under
  `connectMu`, which is nil-safe and repeatable. The behaviour the existing
  `TestHybridPumpShutdown` asserts is unchanged.
- **`Init()` left a running client behind when only the login failed.** Nothing shuts down a pump
  whose `Init` returned an error, so a wrong `api_key` orphaned a full pool for the lifetime of the
  process — an independent leak path. `Init` now releases the client on that branch.

### Deliberately not changed

- `connectRPC` still returns the `Ping` error with the new client assigned. That is now correct and
  bounded: it is the pump's current client, exactly one pool, and every exit path releases it — the
  next `connectRPC`, `Shutdown()`, or the new `Init` cleanup. Keeping it assigned preserves how the
  pump recovers when MDCB comes back.
- The `OnConnect` method value bound to the pump is now moot rather than a hazard: `Stop()` waits
  for the handler goroutines, and `OnConnect` is only reachable from them, so no stopped client can
  write `clientIsConnected` afterwards.
- ~~A "someone else already reconnected, reuse their client" short-circuit.~~ Originally left out
  as an optimisation. Review showed it is not optional — see the addendum at the end, which adds
  it.

## Tests

Six new tests in `pumps/hybrid_test.go`, with two more and one extended assertion added by the
addendum, for eight in total. **Every one of them was confirmed to fail against the code it
guards**, which matters here because nothing about the leak is observable from the pump's own
behaviour.

| Test | What it pins down | Unpatched result |
|---|---|---|
| `TestConnectRPCStopsPreviousClient` | reconnecting leaves exactly one live client, and the replaced one is actually stopped | 2 clients × 3 connections, and `Stop()` on the old one does not panic |
| `TestConnectAndLoginRetryDoesNotOrphanClients` | the `retryAndLog` path builds several clients but leaves one | 3 clients × 2 connections |
| `TestConcurrentReconnectKeepsSingleClient` | overlapping recoveries leave one client, none stopped from under another, no torn state | 9 clients × 2 connections, or `fatal error: concurrent map writes` |
| `TestShutdownWithoutClient` | `Shutdown` on a pump that never connected | nil-pointer dereference |
| `TestShutdownIsIdempotent` | `Shutdown` twice | nil-pointer dereference |
| `TestInitFailureReleasesRPCClient` | a failed `Init` keeps no client | client kept, 2 connections open |

### How they observe the leak

The pump generates one connection id per `connectRPC` and writes it in its dial handshake, so
"connections still open for id *k*" is exactly "client *k* is still alive". The tests add a
`gorpc.Listener` that counts open connections per id, which is the only place the leak is visible.

Three constraints shaped that choice:

- **No `runtime.NumGoroutine()`.** The package's pre-existing tests already leak clients, and other
  pumps in it run their own background goroutines, so absolute or delta goroutine counts would be
  flaky and would misattribute failures.
- **No reliance on `-race`.** `bin/ci-test.sh` disables the race detector for the `pumps` package,
  so every assertion is a value assertion. `TestConcurrentReconnectKeepsSingleClient` fails
  deterministically without it: `connectRPC` only returns nil after its `Ping` succeeded, so
  pre-fix every one of the nine clients provably has a live connection.
- **No new fixed ports.** The listener owns an ephemeral socket and its `Init` is a no-op, so these
  tests cannot collide with the file's hardcoded 12345/9092/9099 across the three times CI runs this
  package.

`TestConnectRPCStopsPreviousClient` also asserts that stopping the replaced client panics. That is
the only *direct* evidence available that `connectRPC` stopped it, as opposed to its connections
having gone away for some other reason. It is asserted last, because it stops the client itself.

One measured gorpc behaviour is documented in the tests via `rpcReleaseBudget`: after
`Client.Stop()` returns, the server closes its end of each connection either immediately or after
almost exactly ten seconds, never later. This reproduces with no pump involved at all, so the
waits have to clear those ten seconds. An unpatched pump never releases the connections at all, so
the longer budget does not weaken any assertion.

### One drive-by in the test file

`TestHybridConfigParsing` unset its environment variables **by value instead of by key**
(`for _, env := range envs { os.Unsetenv(env) }`, where `env` is `"localhost:9099"`, `"20"`, …),
so its `TYK_PMP_PUMPS_HYBRID_META_*` settings stayed set for every test declared after it — which
is where new tests land. Now iterates keys.

## Verification

Unit tests aside, the fix was checked end to end on a local data plane (worker gateway → worker
Redis → hybrid pump → MDCB) with records flowing continuously and 20 interruptions of the
pump→MDCB path, each longer than `call_timeout`:

| | before | after |
|---|---|---|
| reconnects | 20 | 21 |
| pump established connections | **105** (21 clients × 5) | **5** |
| pump `clientHandler` goroutines | **105** | **5** |
| MDCB connections | 110 | **10** |
| MDCB goroutines (start → peak) | 54 → **339** | 54 → **54** |
| MDCB heap in use | 28 MB → **203 MB** | 27 MB → 36 MB |
| pump goroutines (peak) | 306 | 23 |

Before the fix the growth was exactly linear — connections were always `(reconnects + 1) × 5` and
never dropped. After it they stay at `rpc_pool_size` however often the pump reconnects, and MDCB
returns to its pre-test baseline instead of settling higher.

`gofmt -s`, `goimports`, `go vet` and `golangci-lint` are clean. The `pumps` package passes with
both `MONGO_DRIVER` values, under `-tags=boringcrypto`, and additionally under `-race` (which CI
does not run for this package).

## Scope

tyk-pump only. Two related items are deliberately out of scope and tracked separately: MDCB-side
`server_options.idle_timeout` / `max_connections` hardening, which bounds the damage from any
misbehaving client but does not fix this leak; and a distinct race in the gateway's
`rpc/dns_resolver.go`, which is newer than the reported incidents and cannot explain them.

The defect predates every supported release, so this needs backporting to the supported release
lines.

---

# Addendum: reconnect stampede could break a purge in flight

Raised in review, and valid. Worth stating plainly: **this was a regression introduced by the fix
above, and it loses analytics data.** It is fixed here, in the same change.

## What happens

Several purge cycles can be in flight at once. When the pump has a `timeout` configured,
`execPumpWriting` returns as soon as that deadline passes while the goroutine it started keeps
running `WriteData`; the wait group is satisfied, the purge loop moves on, and the next tick starts
another `WriteData` on the same pump.

If MDCB has gone away, all of those calls fail `RPCLogin` together and all call
`connectAndLogin(false)`, where they queue on `connectMu`. Before this addendum each of them then
reconnected unconditionally:

1. A takes the lock, reconnects, publishes client A, releases the lock, returns nil.
2. A goes on to `callRPCFn("PurgeAnalyticsData")` through client A.
3. B takes the lock and calls `connectRPC()`, which calls `stopClient()`.
4. B stops client A underneath A.
5. A's call fails — or finds `funcClientSingleton` already nil and gets `not connected to Tyk MDCB`.

**Those records are then gone.** `StartPurgeLoop` reads analytics with
`AnalyticsStore.GetAndDeleteSet(...)`, so they have already been deleted from the temporal store by
the time any pump sees them, and `execPumpWriting` reports a failed write as
`Warning("Error Writing to: …")` with no retry and no re-queue.

The reason this is new: before the fix, the replaced client was never stopped. It leaked, but it
stayed connected and usable, so a call in flight through it still completed. Adding `stopClient()`
turned a silent leak into a broken write. Only step 4 is new behaviour, and it is the step that
costs data.

## The fix

A generation counter, `clientGen atomic.Uint64`, incremented wherever a client is published.
`connectAndLogin` reads it **before** queueing on the lock, and once it holds the lock a changed
value means another recovery has already replaced the client this one set out to replace. It then
probes that client with `RPCLogin` and, if it answers, returns without touching it.

Reading the generation before taking the lock rather than after is the part that matters. After
would still rebuild in the case where the failure was observed on the old client but the read
happened once the replacement was already published.

Rejected credentials are returned rather than reconnected around: `ErrRPCLogin` means another client
would be given the same answer, so rebuilding would only tear down a working connection.

Two useful consequences beyond the data loss:

- The stampede collapses. Eight overlapping recoveries now build **one** client between them
  instead of eight, so a reconnect no longer multiplies into a burst of connects against an MDCB
  that has only just come back — which is the condition this whole ticket is about.
- The common path is unaffected. A lone recovery sees an unchanged generation and goes straight to
  reconnecting, with no extra round trip.

## Tests

Three, all confirmed to fail against the fix *without* the short-circuit — that is, against the
state of this branch before the addendum, which is the code they actually guard.

| Test | Result without the short-circuit |
|---|---|
| `TestQueuedRecoveryReusesTheNewClient` | the queued recovery built another client and replaced the working one; the failure output shows the published client with `clientStopChan: nil`, stopped while a purge was using it |
| `TestQueuedRecoveryKeepsClientWhenCredentialsAreRejected` | a rejected login triggered a rebuild and replaced a working client |
| `TestConcurrentReconnectKeepsSingleClient` (extended) | **9** clients built, against a bound of 3 |

The first two encode the numbered sequence above deterministically rather than racing for it: the
test file is in the same package, so it holds `connectMu` itself, lets a second recovery queue
behind it, publishes a client under the lock, and then releases. `TestQueuedRecoveryReusesTheNewClient`
finishes by making a real `PurgeAnalyticsData` call through the reused client, so the assertion is
the write path itself rather than a proxy for it.

## One residual, deliberately

A *single* recovery that legitimately reconnects — its own login genuinely failed — while another
purge is mid-write will still stop that client, and that write still fails. Closing it needs
per-client reference counting so `stopClient` drains in-flight calls first, which means either
holding a lock across an RPC or wrapping every client.

Not done here, on the grounds that the client is broken by hypothesis in that case, so the write was
already unlikely to complete, and before this change it only appeared to succeed because it was
riding a leaked client.

Related but wider than this PR: **the data loss itself is not hybrid-specific.** Any pump loses its
batch when `WriteData` fails, because the purge loop deletes the records before handing them over
and a failure is only logged. That is worth its own ticket.
<!---TykTechnologies/jira-linter starts here-->

### Ticket Details

<details>
<summary>
<a href="https://tyktech.atlassian.net/browse/TT-14423" title="TT-14423" target="_blank">TT-14423</a>
</summary>

|         |    |
|---------|----|
| Status  | In Code Review |
| Summary | High memory consumption on MDCB caused by leaked RPC clients in the hybrid Pump |

Generated at: 2026-08-26 10:12:48

</details>

<!---TykTechnologies/jira-linter ends here-->
